### PR TITLE
fix: Prevent FFmpeg from consuming stdin

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -96,6 +96,7 @@ Release dates are in YYYY-MM-DD format.
   - Thread safety in async operations
   - File system operations
   - FFmpeg path detection
+  - FFmpeg reliability
   - Poetry virtualenv configuration
   - Pre-commit hooks formatting
   - Pytest configuration parameters

--- a/tracklistify/core/base.py
+++ b/tracklistify/core/base.py
@@ -149,6 +149,7 @@ class AsyncApp:
         base_cmd = [
             "ffmpeg",
             "-hide_banner",
+            "-nostdin",  # Disable stdin processing (can break the shell)
             "-loglevel",
             "error",
             "-i",


### PR DESCRIPTION
By default, FFmpeg runs in an "interactive" mode which lets the user
interact with FFmpeg while it is running by pressing keys.  When
FFmpeg is being run as a subprocess or background task, this feature
needs to be disabled to prevent FFmpeg from unintentionally capturing
stdin.  FFmpeg's default behavior caused an odd bug with tracklistify
when processing certain types of files (.mp4 files) which would
trigger this behavior and break the shell's echo.

Per the FFmpeg FAQ, this feature can be disabled by either using the
-nostdin flag, or by redirecting /dev/null (or NUL) to stdin.  I
chose the former since it is more portable.

https://ffmpeg.org/faq.html#How-do-I-run-ffmpeg-as-a-background-task_003f
