### PR TITLE
refactor: simplify clear_config method and improve track similarity c…

### DIFF
--- a/tracklistify/config/factory.py
+++ b/tracklistify/config/factory.py
@@ -56,7 +56,7 @@ def get_config(force_refresh: bool = False) -> TrackIdentificationConfig:
 
 def clear_config() -> None:
     """Clear global configuration instance."""
-    ConfigFactory.clear_cache(TrackIdentificationConfig)
+    ConfigFactory.clear_cache()
 
 
 class ConfigError(Exception):

--- a/tracklistify/core/track.py
+++ b/tracklistify/core/track.py
@@ -41,8 +41,6 @@ class Track:
         if not other.config:
             other.config = self.config
 
-        time_threshold = self.config.time_threshold
-
         # Normalize strings for comparison
         def normalize(s: str) -> str:
             return re.sub(r"[^\w\s]", "", s.lower())
@@ -52,21 +50,12 @@ class Track:
         other_song = normalize(other.song_name)
         other_artist = normalize(other.artist)
 
-        # Check for exact matches first
+        # Check for exact matches of both song and artist
         if this_song == other_song and this_artist == other_artist:
             return True
 
-        # Use time_threshold to compare time_in_mix
-        def time_to_seconds(time_str: str) -> int:
-            h, m, s = map(int, time_str.split(":"))
-            return h * 3600 + m * 60 + s
-
-        this_time = time_to_seconds(self.time_in_mix)
-        other_time = time_to_seconds(other.time_in_mix)
-
-        if abs(this_time - other_time) <= time_threshold:
-            return True
-
+        # Tracks are NOT similar if they have different songs or artists
+        # regardless of time proximity
         return False
 
     def __init__(


### PR DESCRIPTION
This pull request refactors the track similarity logic in `tracklistify/core/track.py` and simplifies the configuration cache clearing in `tracklistify/config/factory.py`. The main change is to make track similarity depend strictly on exact matches of song and artist, removing time-based similarity checks.

Track similarity logic changes:

* The `is_similar_to` method in `Track` now only returns `True` if both the song name and artist match exactly (case-insensitive, punctuation removed). Time-based similarity using `time_threshold` and `time_in_mix` has been removed, so tracks with different song or artist are never considered similar, regardless of time proximity. [[1]](diffhunk://#diff-7de142bc8bb87dd63180c0f3e8db2209b4bae2df84a43e9cc93d6b88a6b1506fL44-L45) [[2]](diffhunk://#diff-7de142bc8bb87dd63180c0f3e8db2209b4bae2df84a43e9cc93d6b88a6b1506fL55-R58)

Configuration management:

* The `clear_config` function now calls `ConfigFactory.clear_cache()` without specifying the configuration class, simplifying the cache clearing process.…heck logic