### PR TITLE
feat: add delay between Shazam API requests to avoid rate limiting

### DIFF
--- a/tracklistify/providers/shazam.py
+++ b/tracklistify/providers/shazam.py
@@ -1,6 +1,7 @@
 """Shazam track identification provider using shazamio."""
 
 # Standard library imports
+import asyncio
 from typing import Any, Dict, Optional
 
 # Third-party imports
@@ -23,6 +24,7 @@ class ShazamProvider(TrackIdentificationProvider):
     async def identify_track(self, audio_segment) -> Optional[Dict[str, Any]]:
         """Identify track from an audio segment."""
         try:
+            await asyncio.sleep(2.25)
             logger.info(f"Identifying segment at {audio_segment.start_time}s")
 
             # Ensure the audio file path is valid


### PR DESCRIPTION
This pull request introduces a minor update to the Shazam provider, specifically adding a delay before track identification to potentially improve reliability or timing.

* Added an `asyncio.sleep(2.25)` delay at the start of the `identify_track` method in `tracklistify/providers/shazam.py` to pause execution before processing each audio segment.
* Imported the `asyncio` module to support the new asynchronous sleep functionality.