### PR TITLE
feat(project): add project root discovery utilities

### DIFF
--- a/src/tracklistify/cli.py
+++ b/src/tracklistify/cli.py
@@ -13,6 +13,7 @@ from .core import ApplicationError, AsyncApp
 
 # Local/package imports
 from .utils.logger import get_logger, set_logger
+from .utils.project import get_project_root
 
 # Get the logger for this module
 logger = get_logger(__name__)
@@ -145,8 +146,8 @@ def cli() -> None:
     logger.info("Starting CLI")
 
     # Load environment variables first
-    env_path = Path(__file__).parent.parent / ".env"
-    load_environment_variables(env_path)
+    env_file = get_project_root() / ".env"
+    load_environment_variables(env_file)
 
     try:
         exit_code = asyncio.run(main(args))

--- a/src/tracklistify/core/run.py
+++ b/src/tracklistify/core/run.py
@@ -1,9 +1,10 @@
-#!/usr/bin/env python3
+"""Main entry point for Tracklistify."""
 
 import asyncio
 import signal
 import sys
-from pathlib import Path
+
+from .utils.project import get_project_root
 
 # Global variables for cleanup
 _cleanup_tasks = set()
@@ -11,15 +12,10 @@ _cleanup_tasks = set()
 
 def setup_environment():
     """Setup the Python path and environment variables."""
-    # Add the parent directory to Python path so tracklistify can be imported
-    current_dir = Path(__file__).parent.absolute()
-    sys.path.append(str(current_dir))
-
-    # Load environment variables from .env file if it exists
-    env_file = current_dir / ".env"
-    if not env_file.exists() and (current_dir / ".env.example").exists():
+    env_file = get_project_root() / ".env"
+    if not env_file.exists() and (get_project_root() / ".env.example").exists():
         print("Creating .env from .env.example...")
-        with open(current_dir / ".env.example") as f:
+        with open(get_project_root() / ".env.example") as f:
             with open(env_file, "w") as env:
                 env.write(f.read())
         print("Please edit .env with your credentials")

--- a/src/tracklistify/utils/project.py
+++ b/src/tracklistify/utils/project.py
@@ -1,0 +1,74 @@
+"""Project root discovery utilities."""
+
+import os
+from functools import lru_cache
+from importlib.metadata import PackageNotFoundError, distribution
+from pathlib import Path
+
+from .logger import get_logger
+
+logger = get_logger(__name__)
+
+
+class ProjectRootError(Exception):
+    """Raised when project root cannot be determined."""
+
+    pass
+
+
+@lru_cache(maxsize=1)
+def get_project_root() -> Path:
+    """Get project root directory with multiple fallback strategies.
+
+    The result is cached for performance as project root doesn't change during runtime.
+
+    Returns:
+        Path: Absolute path to the project root directory
+
+    Raises:
+        ProjectRootError: If project root cannot be determined reliably
+    """
+
+    project_root_env = os.getenv("TRACKLISTIFY_PROJECT_ROOT")
+
+    if project_root_env:
+        try:
+            project_root = Path(project_root_env).resolve()
+            if project_root.exists():
+                return project_root
+        except (OSError, ValueError):
+            pass
+
+    current_file = Path(__file__).resolve()
+
+    for parent in [current_file] + list(current_file.parents):
+        pyproject_path = parent / "pyproject.toml"
+        if pyproject_path.exists():
+            return parent
+
+    try:
+        dist = distribution("tracklistify")
+        package_path = Path(dist.locate_file(""))
+
+        if (package_path / "pyproject.toml").exists():
+            return package_path
+
+        for parent in package_path.parents:
+            pyproject_path = parent / "pyproject.toml"
+            if pyproject_path.exists():
+                return parent
+
+    except (PackageNotFoundError, AttributeError, OSError):
+        pass
+
+    raise ProjectRootError(
+        "Unable to determine project root. Please set TRACKLISTIFY_PROJECT_ROOT "
+        "environment variable or ensure pyproject.toml exists in the project root."
+    )
+
+
+def clear_project_root_cache() -> None:
+    """Clear the cached project root."""
+
+    get_project_root.cache_clear()
+    logger.debug("Cleared project root cache")


### PR DESCRIPTION
This pull request refactors how the project root directory is determined and accessed throughout the codebase, improving reliability and maintainability. The main change is the introduction of a centralized utility function for project root discovery, which replaces previous ad-hoc methods in multiple modules.

**Project root discovery improvements:**

* Added a new utility module `src/tracklistify/utils/project.py` that provides the `get_project_root()` function, which reliably determines the project root using multiple fallback strategies and caches the result for performance.
* Updated imports in `src/tracklistify/cli.py` and `src/tracklistify/core/run.py` to use the new `get_project_root()` utility instead of manual path calculations. [[1]](diffhunk://#diff-94dfeb50e75ba80bef6251c4e06d34e40aef3771999aae3a848ace7f3f07153fR16) [[2]](diffhunk://#diff-ae50d58c63b115c193dbaaa5e245b3c1b1c68c25e36108f892b58bfb5eae4c12L1-R18)

**Environment variable loading consistency:**

* Refactored environment variable loading in `src/tracklistify/cli.py` and `src/tracklistify/core/run.py` to use the project root determined by `get_project_root()`, ensuring consistent behavior across entry points. [[1]](diffhunk://#diff-94dfeb50e75ba80bef6251c4e06d34e40aef3771999aae3a848ace7f3f07153fL148-R150) [[2]](diffhunk://#diff-ae50d58c63b115c193dbaaa5e245b3c1b1c68c25e36108f892b58bfb5eae4c12L1-R18)

**Error handling and caching:**

* Introduced a custom exception `ProjectRootError` for clearer error reporting when the project root cannot be determined, and added a cache-clearing function for the project root utility.