### PR TITLE
Lightweight optimizations, latent bug fixes, and circuit-breaker wiring

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -38,6 +38,8 @@ modernises the test suite, and tightens lint/format hygiene.
   their status.
 - `CLAUDE.md` at repo root with a comprehensive guide for AI-assisted
   development (project layout, conventions, common tasks).
+- `docs/IMPROVEMENT_PLAN.md` — technical documentation of the PR #44
+  optimizations/fixes plus a prioritized, risk-classified follow-up backlog.
 
 ### Changed
 

--- a/docs/IMPROVEMENT_PLAN.md
+++ b/docs/IMPROVEMENT_PLAN.md
@@ -1,0 +1,212 @@
+# Optimization & Improvement Plan
+
+Technical companion to PR #44 (*Lightweight optimizations, latent bug fixes, and
+circuit-breaker wiring*). It documents the changes that shipped in this PR and
+lays out a prioritized, risk-classified backlog for follow-up work.
+
+The guiding constraint for everything in **Part A** was **no behavioral
+regression**: each change is either behavior-identical, or repairs a path that
+was already broken. Items deferred because they *do* change behavior are
+captured in **Part B** so the trade-offs are explicit rather than lost.
+
+- Tests: `uv run python -m pytest -q` → **382 passed** (pytest 9.0.3, asyncio strict)
+- Lint/format: `uv run ruff check src/ tests/` + `ruff format --check` → clean
+- Dead code: `uv run vulture src/tracklistify` → no new findings
+
+---
+
+## Risk / effort legend
+
+| Tag | Meaning |
+|-----|---------|
+| 🟢 Low | Behavior-identical or repairs a broken path; covered by tests |
+| 🟡 Medium | Observable behavior change, but bounded and config-gated |
+| 🔴 High | Changes concurrency / ordering / public semantics; needs design + new tests |
+
+---
+
+## Part A — Delivered in PR #44
+
+### A1. Performance (behavior-preserving) — `perf:`
+
+| Change | File(s) | Notes |
+|--------|---------|-------|
+| **O(n) track de-duplication** | `core/track.py::TrackMatcher.get_unique_tracks` | Replaced an O(n²) `next()`-scan + `list.remove()` + double-sort with a single dict pass keyed by `artist|song`, then one sort. Tie-break preserved: earliest occurrence wins among equal confidence; highest confidence wins overall. |
+| **Cache size reuse** | `cache/invalidation.py::SizeStrategy.update_metadata`, `cache/base.py` | Reuse the `size` computed at set-time instead of re-running `json.dumps(value)` on every cache access. `SizeStrategy` returns the entry unchanged when size is known, so it no longer forces a storage rewrite (access-time updates from `LRUStrategy` are a separate concern — see B5). |
+| **Shazam cooldown hoist** | `providers/shazam.py` | The inter-request cooldown was re-read from config (with a `try/except`) on every segment; now resolved once in `__init__`. |
+| **Magic number → constant** | `core/base.py` | Segment-size validation uses `MIN_SEGMENT_FILE_SIZE` (already in `utils/constants.py`) instead of the literal `1000`. |
+| **Precompiled regexes** | `exporters/tracklist.py` | Filename-sanitization patterns compiled once at module level. |
+| **Parallel Spotify enrichment** | `providers/spotify.py::get_track_details` | The independent `tracks/{id}` and `audio-features/{id}` requests now run via `asyncio.gather`. |
+| **Dead code removal** | `downloaders/ytdlp.py` | Removed unused `get_ydl_opts()` (download builds opts inline) and the now-unused `tempfile` import. |
+
+### A2. Correctness fixes (repair broken paths) — `fix:`
+
+- **ACRCloud factory** (`providers/factory.py`): `ACRCloudProvider()` was constructed
+  with no arguments, raising `TypeError` the moment `acrcloud` was selected. The
+  factory now reads `TRACKLISTIFY_ACR_ACCESS_KEY` / `_ACCESS_SECRET` (and optional
+  `_HOST`) from the environment — the documented credential design — and raises a
+  clear `ProviderError` when they're absent.
+- **ACRCloud protocol mismatch** (`providers/acrcloud.py`): `identify_track` expected
+  raw `bytes`, but the identification loop and the base provider protocol pass an
+  `AudioSegment`. It now accepts a segment (reading bytes from `file_path`, using
+  its `start_time`) while still accepting raw bytes for direct/back-compat use.
+  Together with the factory fix, ACRCloud can now run end-to-end.
+- **Spotify downloader event-loop crash** (`downloaders/spotify.py`): `_set_metadata`
+  called `asyncio.run()` while already inside the running `download()` loop —
+  `RuntimeError` whenever a track had cover art. `_set_metadata` is now `async` and
+  awaits the cover fetch; the call site awaits it.
+
+### A3. Reliability — `feat:`
+
+- **Circuit breaker wired into the request path**
+  (`utils/identification.py`, `utils/rate_limiter.py`). The breaker was implemented
+  but never invoked in production, so `circuit_state` never opened. The
+  identification loop now reports each provider request outcome via the new public
+  `RateLimiter.record_result(provider, success)`:
+  - a `None`/no-match result still counts as **success** (resets the failure streak);
+  - an exception from `identify_track` counts as **failure**.
+
+  After `circuit_breaker_threshold` consecutive failures (default 5), `acquire`
+  short-circuits and segments are skipped until `circuit_breaker_reset_timeout`
+  (default 60s). Config-gated via `circuit_breaker_enabled`.
+- **Bounded metrics** (`utils/rate_limiter.py`): `rate_limit_windows` is capped at
+  `MAX_RATE_LIMIT_WINDOWS` so long runs don't grow the list without bound.
+
+### A4. Refactors — `refactor:`
+
+- `core/base.py`: extracted `_build_identification_manager()` (removing duplicated
+  construction); declared `original_title` / `uploader` / `duration` /
+  `_output_formats` in `__init__` (removing scattered `getattr` fallbacks); replaced
+  two duplicated duration `try/float/except` blocks with `_coerce_float()`. The
+  `_output_formats → config.output_format` fallback is preserved via `or`.
+- `providers/acrcloud.py`: collapsed a confusing nested `try/except` (the outer
+  handler re-wrapped the `ProviderError` the inner one raised) into a single
+  `JSONDecodeError` handler.
+
+### A5. Dependency maintenance
+
+Merged 5 Dependabot `chore(deps)` PRs into `main` after verifying the full set
+together against the test suite (notably the **pytest 8 → 9** major bump):
+`aiohttp 3.13.4`, `urllib3 2.7.0`, `python-dotenv 1.2.2`, `idna 3.15`,
+`pytest 9.0.3` (+ `pytest-httpx 0.36.2`). The suite is green on pytest 9.0.3.
+
+### A6. Test coverage added
+
+- `tests/test_provider_factory.py` — ACRCloud credential wiring (missing/partial
+  creds raise, env creds construct, host override, caching, unknown provider).
+- `tests/test_providers_acrcloud.py` — `identify_track` response handling (success,
+  no-result code → empty music, HTTP 401/429 → typed errors, invalid JSON, and the
+  `AudioSegment` input path).
+- `tests/test_identification_circuit_breaker.py` — breaker trips after repeated
+  failures (and stops calling the provider); `record_result` resets the streak.
+
+---
+
+## Part B — Forward improvement plan (prioritized backlog)
+
+### B1. 🟡 Shazam error semantics & circuit-breaker accuracy
+**Problem.** `providers/shazam.py::identify_track` returns `None` on *all* errors,
+including genuine network/provider failures. With the breaker now wired, those
+failures are recorded as **success** (no exception is raised), so the breaker
+never trips for Shazam — the most-used provider.
+**Approach.** Distinguish "no match" (return `None`) from "request failed" (raise
+`ProviderError`/`RateLimitError`), matching ACRCloud/Spotify. The loop already maps
+an exception to a breaker failure.
+**Files.** `providers/shazam.py`; tests in `tests/`.
+**Risk.** 🟡 Changes what the loop sees on Shazam errors; add tests for both paths.
+
+### B2. 🔴 Parallelize per-segment identification
+**Problem.** `utils/identification.py` processes segments strictly sequentially even
+when the rate limiter permits concurrency (`max_concurrent_requests > 1`).
+**Approach.** Dispatch `identify_track` calls under an `asyncio.gather` bounded by
+the existing limiter/semaphore; preserve result ordering and per-call breaker
+accounting; keep the Shazam cooldown semantics intact.
+**Files.** `utils/identification.py`, `utils/rate_limiter.py`.
+**Risk.** 🔴 Interacts with rate limiting, cooldown, ordering, and the breaker.
+Needs careful design and new concurrency tests.
+
+### B3. 🟡 Rate limiter: event-driven token wait
+**Problem.** `RateLimiter.acquire` polls every `TOKEN_REFILL_SLEEP` (10 ms) while
+waiting for tokens — a busy-wait that wakes ~100×/s per waiter.
+**Approach.** Replace the poll loop with an `asyncio.Condition` notified by
+`_refill_tokens`, or compute the exact sleep-until-next-token interval.
+**Files.** `utils/rate_limiter.py`.
+**Risk.** 🟡 Core timing path; existing rate-limiter tests must stay green, add
+tests for wakeup correctness.
+
+### B4. 🟡 Cache storage: bounded per-key locks
+**Problem.** `cache/storage.py` allocates one `asyncio.Lock` per unique key and never
+evicts, so the lock dict grows with the key space.
+**Approach.** Use a bounded pool of locks (hash key → fixed-size lock array) or an
+LRU of locks. Evicting a lock that's in use must be impossible — design carefully.
+**Files.** `cache/storage.py`.
+**Risk.** 🟡–🔴 Concurrency-correctness sensitive.
+
+### B5. 🟡 Cache: avoid write-on-every-hit for access metadata
+**Problem.** `cache/base.py::get` rewrites the entry to storage whenever
+`update_metadata` changes `last_accessed`, i.e. on most hits — disk I/O on the hot
+read path.
+**Approach.** Sample/throttle access-time updates (e.g. only persist every Nth hit
+or after a time delta), or keep access metadata in memory and flush periodically.
+**Files.** `cache/base.py`, `cache/invalidation.py`.
+**Risk.** 🟡 Slightly staler LRU/access stats; behavior otherwise unchanged.
+
+### B6. 🟢 Spotify `enrich_metadata` silent no-op
+**Problem.** When `search_track` finds no match, the input dict is returned
+unchanged with no signal — callers can't tell "enriched" from "not found".
+**Approach.** Log at debug and/or annotate the result (e.g. `enriched: False`).
+**Files.** `providers/spotify.py`.
+**Risk.** 🟢 Additive.
+
+### B7. 🔴 Spotify `add_tracks_to_playlist` batch concurrency
+**Problem.** 100-track batches are added sequentially.
+**Caveat.** Parallelizing with `asyncio.gather` can **reorder** tracks in the
+playlist — a behavior change. Only pursue if order-preservation is guaranteed
+(e.g. position indices) or order is deemed unimportant.
+**Files.** `providers/spotify.py`.
+**Risk.** 🔴 Ordering semantics.
+
+### B8. 🟡 Decouple CLI overrides from config mutation
+**Problem.** `core/base.py::process_input` mutates the shared config singleton
+(`self.config.primary_provider = ...`) and rebuilds the manager mid-run.
+**Approach.** Pass overrides explicitly or use a per-run config copy, so the global
+singleton isn't mutated.
+**Files.** `core/base.py`, `config/`.
+**Risk.** 🟡 Touches config lifecycle; singleton tests must stay green.
+
+### B9. 🟢 Non-blocking audio metadata probe
+**Problem.** `core/base.py::split_audio` calls synchronous `mutagen.File()` on the
+event loop. (An earlier attempt was reverted because `split_audio` is synchronous.)
+**Approach.** Make `split_audio` async and `await asyncio.to_thread(File, ...)`, or
+provide an async wrapper; update its single caller and tests.
+**Files.** `core/base.py` and tests calling `split_audio`.
+**Risk.** 🟢–🟡 Mechanical but ripples into the caller/tests.
+
+### B10. 🟢 Circuit breaker HALF_OPEN re-open
+**Problem.** `_update_circuit_breaker` only transitions `CLOSED → OPEN`; a failure
+while `HALF_OPEN` doesn't re-open the circuit (it waits for the next success or
+another full threshold from CLOSED).
+**Approach.** On failure in `HALF_OPEN`, transition straight back to `OPEN` and
+reset `circuit_open_time`.
+**Files.** `utils/rate_limiter.py`; extend breaker tests.
+**Risk.** 🟢 Small, well-scoped state-machine fix.
+
+---
+
+## Part C — Verification & conventions
+
+```bash
+uv sync
+uv run python -m pytest -q                 # full suite (use `python -m`, not bare pytest)
+uv run ruff check src/ tests/              # lint
+uv run ruff format --check src/ tests/     # format gate
+uv run vulture src/tracklistify            # dead-code scan
+```
+
+Conventions when picking up a backlog item:
+- One change per concern; Conventional Commits (`feat`/`fix`/`perf`/`refactor`/…).
+- Add or extend tests **in the same change**; prefer mocking `_api_request` /
+  `_get_session` over network access.
+- For config-touching tests, `get_config(force_refresh=True)` and
+  `monkeypatch.delenv("TRACKLISTIFY_*", raising=False)`.
+- Keep behavior changes (Part B 🟡/🔴) gated/flagged and called out in the PR.

--- a/src/tracklistify/cache/invalidation.py
+++ b/src/tracklistify/cache/invalidation.py
@@ -284,8 +284,15 @@ class SizeStrategy(InvalidationStrategy[T]):
             return False
 
     async def update_metadata(self, entry: CacheEntry[T]) -> CacheEntry[T]:
-        """Update entry metadata."""
+        """Update entry metadata.
+
+        The size is computed once at set-time (see ``BaseCache.set``); reuse it
+        when present instead of re-serializing the (potentially large) value on
+        every access.
+        """
         try:
+            if "size" in entry["metadata"]:
+                return entry
             entry = copy.deepcopy(entry)
             entry["metadata"]["size"] = len(json.dumps(entry["value"]))
             return entry

--- a/src/tracklistify/core/base.py
+++ b/src/tracklistify/core/base.py
@@ -61,7 +61,11 @@ class AsyncApp:
         self.temp_dir.mkdir(parents=True, exist_ok=True)
 
         # Always recreate identification_manager with fresh config
-        self.identification_manager = IdentificationManager(
+        self.identification_manager = self._build_identification_manager()
+
+    def _build_identification_manager(self) -> IdentificationManager:
+        """Create an IdentificationManager bound to the current config."""
+        return IdentificationManager(
             config=self.config, provider_factory=self.provider_factory
         )
 
@@ -122,9 +126,7 @@ class AsyncApp:
                 self.logger.info(f"Overriding primary provider: {provider}")
                 self.config.primary_provider = provider
                 # Recreate identification manager with updated config
-                self.identification_manager = IdentificationManager(
-                    config=self.config, provider_factory=self.provider_factory
-                )
+                self.identification_manager = self._build_identification_manager()
 
             if fallback_enabled is not None:
                 self.logger.info(f"Overriding fallback_enabled: {fallback_enabled}")

--- a/src/tracklistify/core/base.py
+++ b/src/tracklistify/core/base.py
@@ -60,6 +60,14 @@ class AsyncApp:
         self._sweep_stale_run_dirs()
         self.temp_dir.mkdir(parents=True, exist_ok=True)
 
+        # Per-run input metadata, populated by process_input(). Declared here so
+        # the attributes always exist (no getattr fallbacks needed downstream).
+        self.original_title = ""
+        self.uploader = ""
+        self.duration = 0.0
+        # CLI output-format override; None means "fall back to config".
+        self._output_formats = None
+
         # Always recreate identification_manager with fresh config
         self.identification_manager = self._build_identification_manager()
 
@@ -68,6 +76,14 @@ class AsyncApp:
         return IdentificationManager(
             config=self.config, provider_factory=self.provider_factory
         )
+
+    @staticmethod
+    def _coerce_float(value, default: float = 0.0) -> float:
+        """Best-effort float conversion, returning ``default`` on bad input."""
+        try:
+            return float(value)
+        except (TypeError, ValueError):
+            return default
 
     def _sweep_stale_run_dirs(self) -> None:
         """Remove temp subdirs owned by PIDs that no longer exist.
@@ -132,9 +148,9 @@ class AsyncApp:
                 self.logger.info(f"Overriding fallback_enabled: {fallback_enabled}")
                 self.config.fallback_enabled = fallback_enabled
 
-            # Store formats for output. When formats is None, leave
-            # _output_formats unset so the save block falls back to
-            # self.config.output_format via getattr default.
+            # Store formats for output. When formats is None, _output_formats
+            # stays None (its __init__ default) and the save block falls back
+            # to self.config.output_format.
             if formats is not None:
                 self.logger.info(f"Output formats: {formats}")
                 self._output_formats = formats
@@ -181,10 +197,7 @@ class AsyncApp:
                     self.logger.debug(f"yt-dlp metadata keys: {list(metadata.keys())}")
                     self.original_title = sanitizer(metadata.get("title", ""))
                     self.uploader = sanitizer(metadata.get("uploader", ""))
-                    try:
-                        self.duration = float(metadata.get("duration", 0))
-                    except (TypeError, ValueError):
-                        self.duration = 0
+                    self.duration = self._coerce_float(metadata.get("duration", 0))
                 else:
                     self.logger.debug("No metadata available, using fallback values")
                     self.original_title = sanitizer(
@@ -193,10 +206,9 @@ class AsyncApp:
                     self.uploader = sanitizer(
                         getattr(downloader, "uploader", "Unknown artist")
                     )
-                    try:
-                        self.duration = float(getattr(downloader, "duration", 0))
-                    except (TypeError, ValueError):
-                        self.duration = 0
+                    self.duration = self._coerce_float(
+                        getattr(downloader, "duration", 0)
+                    )
 
             self.logger.info("Processing audio...")
 
@@ -205,7 +217,7 @@ class AsyncApp:
             # doesn't have to re-probe — mutagen doesn't read every
             # container we now allow under --stream-copy (e.g. .webm).
             audio_segments = self.split_audio(
-                local_path, duration_hint=getattr(self, "duration", 0) or None
+                local_path, duration_hint=self.duration or None
             )
             if not audio_segments:
                 raise ValueError("No audio segments were created")
@@ -219,7 +231,7 @@ class AsyncApp:
                 context = {
                     "segments_created": len(audio_segments),
                     "input_path": validated_path,
-                    "file_duration": getattr(self, "duration", "unknown"),
+                    "file_duration": self.duration,
                 }
                 raise TrackIdentificationError(
                     f"No tracks were identified in the audio file. "
@@ -236,9 +248,7 @@ class AsyncApp:
             self.logger.info("Saving output...")
             if len(tracks) > 0:
                 # Use _output_formats if set by CLI, otherwise fall back to config
-                output_format = getattr(
-                    self, "_output_formats", self.config.output_format
-                )
+                output_format = self._output_formats or self.config.output_format
                 await self.save_output(tracks, output_format)
             else:
                 raise ValueError(

--- a/src/tracklistify/core/base.py
+++ b/src/tracklistify/core/base.py
@@ -23,7 +23,11 @@ from tracklistify.core.types import AudioSegment
 from tracklistify.downloaders import DownloaderFactory
 from tracklistify.exporters import TracklistOutput
 from tracklistify.providers.factory import create_provider_factory
-from tracklistify.utils.constants import DEFAULT_SEGMENT_PADDING, FFMPEG_SEGMENT_TIMEOUT
+from tracklistify.utils.constants import (
+    DEFAULT_SEGMENT_PADDING,
+    FFMPEG_SEGMENT_TIMEOUT,
+    MIN_SEGMENT_FILE_SIZE,
+)
 from tracklistify.utils.identification import IdentificationManager
 from tracklistify.utils.logger import get_logger
 from tracklistify.utils.strings import sanitizer
@@ -350,7 +354,7 @@ class AsyncApp:
             try:
                 if params["file"].exists():
                     # Skip if file already exists and has content
-                    if params["file"].stat().st_size > 1000:
+                    if params["file"].stat().st_size > MIN_SEGMENT_FILE_SIZE:
                         return AudioSegment(
                             file_path=str(params["file"]),
                             start_time=int(params["start_time"]),
@@ -366,7 +370,10 @@ class AsyncApp:
                 )
                 self.logger.debug(f"FFmpeg output: {result.stdout}")
 
-                if params["file"].exists() and params["file"].stat().st_size > 1000:
+                if (
+                    params["file"].exists()
+                    and params["file"].stat().st_size > MIN_SEGMENT_FILE_SIZE
+                ):
                     return AudioSegment(
                         file_path=str(params["file"]),
                         start_time=int(params["start_time"]),

--- a/src/tracklistify/core/track.py
+++ b/src/tracklistify/core/track.py
@@ -210,35 +210,25 @@ class TrackMatcher:
         )
 
     def get_unique_tracks(self) -> List[Track]:
-        """Get list of unique tracks, sorted by time in mix."""
-        # Sort tracks by time in mix
+        """Get list of unique tracks, sorted by time in mix.
+
+        Keeps the highest-confidence version of each ``artist|song`` pair.
+        Single pass into a dict (O(n)) followed by one sort, replacing the
+        previous O(n^2) linear-scan-and-remove approach.
+        """
+        # Iterate in time order so that, among equal-confidence duplicates,
+        # the earliest occurrence wins (matching the previous behavior).
         sorted_tracks = sorted(self.tracks, key=lambda t: t.time_to_seconds())
 
-        # Filter out duplicates keeping only the highest confidence version
-        unique_tracks = []
-        seen_tracks = set()
-
+        best_by_key: Dict[str, Track] = {}
         for track in sorted_tracks:
-            # Create a unique key for the track
             track_key = f"{track.artist.lower()}|{track.song_name.lower()}"
-
-            # If seen this track before, or has higher confidence
-            if track_key not in seen_tracks:
-                seen_tracks.add(track_key)
-                unique_tracks.append(track)
-            else:
-                # Find existing track and keep the one with higher confidence
-                existing_track = next(
-                    t
-                    for t in unique_tracks
-                    if f"{t.artist.lower()}|{t.song_name.lower()}" == track_key
-                )
-                if track.confidence > existing_track.confidence:
-                    unique_tracks.remove(existing_track)
-                    unique_tracks.append(track)
+            existing = best_by_key.get(track_key)
+            if existing is None or track.confidence > existing.confidence:
+                best_by_key[track_key] = track
 
         # Sort final list by time in mix
-        return sorted(unique_tracks, key=lambda t: t.time_to_seconds())
+        return sorted(best_by_key.values(), key=lambda t: t.time_to_seconds())
 
     def _create_track_group(self, track: Track) -> List[Track]:
         """Initialize a new track group with a single track."""

--- a/src/tracklistify/downloaders/spotify.py
+++ b/src/tracklistify/downloaders/spotify.py
@@ -3,7 +3,6 @@ Spotify audio downloader implementation.
 """
 
 # Standard library imports
-import asyncio
 import os
 import re
 import subprocess
@@ -248,7 +247,7 @@ class SpotifyDownloader(Downloader):
         """Clean filename by removing illegal characters."""
         return re.sub(ILLEGAL_CHARS_REGEX, ILLEGAL_CHARS_REPLACEMENT, filename)
 
-    def _set_metadata(self, file_path: str, metadata: Dict[str, Any]) -> None:
+    async def _set_metadata(self, file_path: str, metadata: Dict[str, Any]) -> None:
         """Set audio file metadata tags."""
         if self.format == AudioFormat.M4A:
             audio = MP4(file_path)
@@ -297,11 +296,11 @@ class SpotifyDownloader(Downloader):
         if metadata["album"].get("images"):
             cover_url = metadata["album"]["images"][0]["url"]
 
-            async def get_cover():
-                async with self._session.get(cover_url) as response:
-                    return await response.read()
-
-            cover_data = asyncio.run(get_cover())
+            # _set_metadata runs inside the already-running download() event
+            # loop, so await the fetch directly — asyncio.run() here would raise
+            # "cannot be called from a running event loop".
+            async with self._session.get(cover_url) as response:
+                cover_data = await response.read()
             if self.format == AudioFormat.M4A:
                 audio["covr"] = [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]
 
@@ -392,7 +391,7 @@ class SpotifyDownloader(Downloader):
                 temp_path.rename(output_path)
 
             # Set metadata
-            self._set_metadata(output_path, metadata)
+            await self._set_metadata(output_path, metadata)
 
             logger.info(
                 f"Downloaded: {metadata['name']} by {metadata['artists'][0]['name']}"

--- a/src/tracklistify/downloaders/ytdlp.py
+++ b/src/tracklistify/downloaders/ytdlp.py
@@ -5,7 +5,6 @@ yt-dlp video downloader implementation.
 # Standard library imports
 import asyncio
 import os
-import tempfile
 import time
 from pathlib import Path
 from typing import Optional
@@ -163,32 +162,6 @@ class YtDlpDownloader(Downloader):
             elapsed = time.monotonic() - self._pp_started_at
             logger.info(f"Post-processing done in {elapsed:.1f}s")
             self._pp_started_at = None
-
-    def get_ydl_opts(self) -> dict:
-        """Get yt-dlp options with current configuration."""
-        # Prefer the per-invocation temp dir from AsyncApp; fall back to
-        # config (legacy callers) or system temp (last resort).
-        temp_dir = self.temp_dir or self.config.temp_dir or tempfile.gettempdir()
-
-        # Ensure temp directory exists
-        os.makedirs(temp_dir, exist_ok=True)
-
-        return {
-            "format": "bestaudio/best",
-            "postprocessors": [
-                {
-                    "key": "FFmpegExtractAudio",
-                    "preferredcodec": self.format,
-                    "preferredquality": self.quality,
-                }
-            ],
-            "ffmpeg_location": self.ffmpeg_path,
-            "outtmpl": os.path.join(temp_dir, "%(id)s.%(ext)s"),
-            "verbose": True,  # Always set to False to control output
-            "logger": self._logger,
-            "progress_hooks": [progress_hook],
-            "no_warnings": True,  # Suppress unnecessary warnings
-        }
 
     async def download(self, url: str) -> Optional[str]:
         """Download video from URL.

--- a/src/tracklistify/exporters/tracklist.py
+++ b/src/tracklistify/exporters/tracklist.py
@@ -17,6 +17,11 @@ from tracklistify.utils.logger import get_logger
 
 logger = get_logger(__name__)
 
+# Precompiled filename-sanitization patterns (module-level so they're compiled
+# once rather than on every track/filename).
+_INVALID_FILENAME_CHARS_RE = re.compile(r'[<>:"/\\|?*@]')
+_MULTISPACE_RE = re.compile(r"\s+")
+
 
 class TracklistOutput:
     """Handles tracklist output in various formats."""
@@ -67,9 +72,9 @@ class TracklistOutput:
         # Clean up special characters but preserve spaces and basic punctuation
         def clean_string(s: str) -> str:
             # Replace invalid filename characters with spaces
-            s = re.sub(r'[<>:"/\\|?*@]', " ", s)
+            s = _INVALID_FILENAME_CHARS_RE.sub(" ", s)
             # Replace multiple spaces with single space
-            s = re.sub(r"\s+", " ", s)
+            s = _MULTISPACE_RE.sub(" ", s)
             # Strip leading/trailing spaces
             return s.strip()
 

--- a/src/tracklistify/providers/acrcloud.py
+++ b/src/tracklistify/providers/acrcloud.py
@@ -92,13 +92,36 @@ class ACRCloudProvider(TrackIdentificationProvider):
 
         return {"data": data}
 
-    async def identify_track(self, audio_data: bytes, start_time: float = 0) -> Dict:
+    @staticmethod
+    def _resolve_audio(audio_input, start_time: float):
+        """Normalize the identify_track input to ``(audio_bytes, start_time)``.
+
+        Accepts either an ``AudioSegment``-like object (with ``file_path`` and
+        ``start_time``) — the contract used by the identification loop and the
+        base provider protocol — or raw ``bytes`` for direct/back-compat use.
         """
-        Identify a track from audio data.
+        if isinstance(audio_input, (bytes, bytearray)):
+            return bytes(audio_input), start_time
+
+        file_path = getattr(audio_input, "file_path", None)
+        if not file_path:
+            raise ProviderError(
+                "ACRCloud identify_track requires audio bytes or an audio "
+                "segment with a 'file_path' attribute."
+            )
+        seg_start = getattr(audio_input, "start_time", start_time)
+        with open(file_path, "rb") as fh:
+            return fh.read(), seg_start
+
+    async def identify_track(self, audio_segment, start_time: float = 0) -> Dict:
+        """
+        Identify a track from an audio segment (or raw audio bytes).
 
         Args:
-            audio_data: Raw audio data bytes
-            start_time: Start time in seconds for the audio segment
+            audio_segment: An ``AudioSegment``-like object exposing ``file_path``
+                and ``start_time`` (the protocol used by the identification
+                loop), or raw audio ``bytes`` for direct use.
+            start_time: Fallback start time when raw bytes are supplied.
 
         Returns:
             Dict containing track information
@@ -110,6 +133,7 @@ class ACRCloudProvider(TrackIdentificationProvider):
             ProviderError: For other provider-related errors
         """
         try:
+            audio_data, start_time = self._resolve_audio(audio_segment, start_time)
             session = await self._get_session()
             request_data = self._prepare_request_data(audio_data, start_time)
 

--- a/src/tracklistify/providers/acrcloud.py
+++ b/src/tracklistify/providers/acrcloud.py
@@ -128,18 +128,12 @@ class ACRCloudProvider(TrackIdentificationProvider):
                 elif response.status != 200:
                     raise ProviderError(f"ACRCloud API error: {response.status}")
 
+                text_response = await response.text()
                 try:
-                    text_response = await response.text()
-                    try:
-                        result = json.loads(text_response)
-                    except json.JSONDecodeError:
-                        raise ProviderError(
-                            "Failed to parse ACRCloud response. "
-                            f"Response text: {text_response[:200]}"
-                        ) from None
-                except Exception as err:
+                    result = json.loads(text_response)
+                except json.JSONDecodeError as err:
                     raise ProviderError(
-                        f"Failed to parse ACRCloud response. "
+                        "Failed to parse ACRCloud response. "
                         f"Response text: {text_response[:200]}"
                     ) from err
 

--- a/src/tracklistify/providers/factory.py
+++ b/src/tracklistify/providers/factory.py
@@ -1,9 +1,11 @@
 """Provider factory for creating track identification providers."""
 
 # Standard library imports
+import os
 import threading
 
 # Local imports
+from tracklistify.core.exceptions import ProviderError
 
 _provider_factory = None
 _provider_lock = threading.Lock()
@@ -65,7 +67,22 @@ class ProviderFactory:
             elif provider_name == "acrcloud":
                 from tracklistify.providers.acrcloud import ACRCloudProvider
 
-                provider = ACRCloudProvider()
+                # ACRCloud credentials are read directly from the environment
+                # (see CREDENTIALS_BLOCK in scripts/generate_env_example.py),
+                # not from the config dataclass.
+                access_key = os.getenv("TRACKLISTIFY_ACR_ACCESS_KEY")
+                access_secret = os.getenv("TRACKLISTIFY_ACR_ACCESS_SECRET")
+                if not access_key or not access_secret:
+                    raise ProviderError(
+                        "ACRCloud provider requires TRACKLISTIFY_ACR_ACCESS_KEY "
+                        "and TRACKLISTIFY_ACR_ACCESS_SECRET environment variables."
+                    )
+                host = os.getenv("TRACKLISTIFY_ACR_HOST")
+                provider = (
+                    ACRCloudProvider(access_key, access_secret, host=host)
+                    if host
+                    else ACRCloudProvider(access_key, access_secret)
+                )
             else:
                 raise ValueError(f"Unknown provider: {provider_name}")
             self.providers[provider_name] = provider

--- a/src/tracklistify/providers/shazam.py
+++ b/src/tracklistify/providers/shazam.py
@@ -23,18 +23,22 @@ class ShazamProvider(TrackIdentificationProvider):
     def __init__(self):
         self.shazam = Shazam()
         self._config = get_config()
+        # Resolve the inter-request cooldown once; it's static for the
+        # provider's lifetime, so there's no need to re-read it per segment.
+        try:
+            self._cooldown = float(
+                getattr(self._config, "shazam_cooldown_seconds", 2.25)
+            )
+        except (ValueError, AttributeError, TypeError) as e:
+            logger.debug(f"Failed to get cooldown config, using default: {e}")
+            self._cooldown = 2.25
 
     async def identify_track(self, audio_segment) -> Optional[Dict[str, Any]]:
         """Identify track from an audio segment."""
         try:
             # Brief cooldown to avoid hammering upstream between calls
-            try:
-                cooldown = float(getattr(self._config, "shazam_cooldown_seconds", 2.25))
-            except (ValueError, AttributeError, TypeError) as e:
-                logger.debug(f"Failed to get cooldown config, using default: {e}")
-                cooldown = 2.25
-            if cooldown and cooldown > 0:
-                await asyncio.sleep(cooldown)
+            if self._cooldown and self._cooldown > 0:
+                await asyncio.sleep(self._cooldown)
             logger.info(f"Identifying segment at {audio_segment.start_time}s")
 
             # Ensure the audio file path is valid

--- a/src/tracklistify/providers/spotify.py
+++ b/src/tracklistify/providers/spotify.py
@@ -206,9 +206,10 @@ class SpotifyProvider(MetadataProvider):
             Dict containing detailed track information
         """
         try:
-            track = await self._api_request("GET", f"tracks/{track_id}")
-            audio_features = await self._api_request(
-                "GET", f"audio-features/{track_id}"
+            # The two lookups are independent; fetch them concurrently.
+            track, audio_features = await asyncio.gather(
+                self._api_request("GET", f"tracks/{track_id}"),
+                self._api_request("GET", f"audio-features/{track_id}"),
             )
 
             return {

--- a/src/tracklistify/utils/constants.py
+++ b/src/tracklistify/utils/constants.py
@@ -35,6 +35,9 @@ CIRCUIT_BREAKER_RESET_TIMEOUT = 60.0  # seconds
 CIRCUIT_BREAKER_FAILURE_THRESHOLD = 5
 TOKEN_REFILL_SLEEP = 0.01  # seconds between refill checks
 REFILL_INTERVAL_THRESHOLD = 1.0  # seconds
+# Cap retained rate-limit windows so long-running processes don't grow the
+# metrics list without bound; only the most recent windows are kept.
+MAX_RATE_LIMIT_WINDOWS = 1000
 
 # Provider rate limits (requests per minute)
 SHAZAM_DEFAULT_RPM = 25

--- a/src/tracklistify/utils/identification.py
+++ b/src/tracklistify/utils/identification.py
@@ -212,7 +212,18 @@ class IdentificationManager:
                         )
                         continue
 
-                    track_info = await provider.identify_track(segment)
+                    try:
+                        track_info = await provider.identify_track(segment)
+                    except Exception:
+                        # The provider request itself failed — report it so the
+                        # circuit breaker can trip after repeated failures.
+                        limiter.record_result(provider_name, success=False)
+                        raise
+                    else:
+                        # Request completed; a None/no-match result still counts
+                        # as a successful request (resets the failure streak).
+                        limiter.record_result(provider_name, success=True)
+
                     if track_info is None:
                         logger.debug("Provider returned None for track identification")
                         continue

--- a/src/tracklistify/utils/rate_limiter.py
+++ b/src/tracklistify/utils/rate_limiter.py
@@ -12,7 +12,7 @@ from typing import Any, Callable, Dict, List, Optional, Tuple
 
 # Local/package imports
 from ..config import get_config
-from .constants import TOKEN_REFILL_SLEEP
+from .constants import MAX_RATE_LIMIT_WINDOWS, TOKEN_REFILL_SLEEP
 
 # Rate limiting constants
 # 1ms threshold to detect actual rate limit
@@ -228,8 +228,8 @@ class RateLimiter:
                             # Successful requests that were rate-limited
                             limits.metrics.rate_limited_requests += 1
                             limits.metrics.last_rate_limit = time.monotonic()
-                            limits.metrics.rate_limit_windows.append(
-                                (token_wait_start, time.monotonic())
+                            self._record_rate_limit_window(
+                                limits, token_wait_start, time.monotonic()
                             )
                         return True
 
@@ -238,9 +238,7 @@ class RateLimiter:
 
             # Timeout exceeded - rate limiting failure
             limits.metrics.last_rate_limit = time.monotonic()
-            limits.metrics.rate_limit_windows.append(
-                (token_wait_start, time.monotonic())
-            )
+            self._record_rate_limit_window(limits, token_wait_start, time.monotonic())
             limits.semaphore.release()
             return False
         except BaseException:
@@ -256,6 +254,19 @@ class RateLimiter:
             if limits.semaphore is not None:
                 limits.semaphore.release()
 
+    def _record_rate_limit_window(
+        self, limits: ProviderLimits, start: float, end: float
+    ) -> None:
+        """Append a rate-limit window, keeping only the most recent ones.
+
+        Bounds the list at ``MAX_RATE_LIMIT_WINDOWS`` so a long-running process
+        doesn't accumulate windows without limit.
+        """
+        windows = limits.metrics.rate_limit_windows
+        windows.append((start, end))
+        if len(windows) > MAX_RATE_LIMIT_WINDOWS:
+            del windows[:-MAX_RATE_LIMIT_WINDOWS]
+
     def _refill_tokens(self, limits: ProviderLimits):
         """Refill rate limiting tokens based on elapsed time."""
         now = time.monotonic()  # Use monotonic for elapsed time calculations
@@ -267,6 +278,15 @@ class RateLimiter:
                     limits.max_requests_per_minute, limits.tokens + tokens_to_add
                 )
                 limits.last_update = now
+
+    def record_result(self, provider: Any, success: bool) -> None:
+        """Record the outcome of a request so the circuit breaker can react.
+
+        Public entry point for callers (e.g. the identification loop) to report
+        whether a provider request completed (``success=True``) or raised
+        (``success=False``). Delegates to the circuit-breaker state machine.
+        """
+        self._update_circuit_breaker(provider, success)
 
     def _update_circuit_breaker(self, provider: Any, success: bool):
         """Update circuit breaker state based on request success."""

--- a/tests/test_identification_circuit_breaker.py
+++ b/tests/test_identification_circuit_breaker.py
@@ -1,0 +1,93 @@
+"""Tests that the identification loop feeds request outcomes to the circuit
+breaker, so repeated provider failures trip it and stop hammering the provider.
+"""
+
+from types import SimpleNamespace
+
+import pytest
+
+from tracklistify.utils.identification import IdentificationManager
+from tracklistify.utils.rate_limiter import (
+    get_global_rate_limiter,
+    reset_global_rate_limiter,
+)
+
+
+class _FailingProvider:
+    """Async-context-manager provider whose identify_track always raises."""
+
+    def __init__(self):
+        self.calls = 0
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def identify_track(self, segment):
+        self.calls += 1
+        raise RuntimeError("provider boom")
+
+    async def close(self):
+        pass
+
+
+class _FakeFactory:
+    def __init__(self, provider):
+        self._provider = provider
+
+    def get_identification_provider(self, name):
+        return self._provider
+
+    async def close_all(self):
+        pass
+
+
+class _FakeConfig:
+    primary_provider = "circuit-test-provider"
+
+
+@pytest.fixture(autouse=True)
+def _fresh_global_limiter():
+    reset_global_rate_limiter()
+    yield
+    reset_global_rate_limiter()
+
+
+@pytest.mark.asyncio
+async def test_circuit_breaker_trips_after_repeated_failures(monkeypatch):
+    limiter = get_global_rate_limiter()
+    monkeypatch.setattr(limiter._config, "circuit_breaker_enabled", True)
+    monkeypatch.setattr(limiter._config, "circuit_breaker_threshold", 2)
+    # Keep the circuit open for the duration of the run.
+    monkeypatch.setattr(limiter._config, "circuit_breaker_reset_timeout", 60.0)
+
+    provider = _FailingProvider()
+    manager = IdentificationManager(
+        config=_FakeConfig(), provider_factory=_FakeFactory(provider)
+    )
+
+    segments = [
+        SimpleNamespace(start_time=i, file_path=f"/tmp/seg{i}.mp3") for i in range(6)
+    ]
+    result = await manager.identify_tracks(segments)
+
+    assert result == []
+    # Only the threshold number of failures actually reach the provider; once
+    # the circuit opens, the remaining segments are rejected by acquire().
+    assert provider.calls == 2
+    metrics = limiter.get_metrics("circuit-test-provider")
+    assert metrics["circuit_state"] == "open"
+
+
+def test_record_result_resets_failure_streak_on_success():
+    limiter = get_global_rate_limiter()
+    limiter.register_provider("p")
+
+    limiter.record_result("p", success=False)
+    limiter.record_result("p", success=False)
+    assert limiter._provider_limits["p"].consecutive_failures == 2
+
+    limiter.record_result("p", success=True)
+    assert limiter._provider_limits["p"].consecutive_failures == 0

--- a/tests/test_provider_factory.py
+++ b/tests/test_provider_factory.py
@@ -1,0 +1,62 @@
+"""Tests for the provider factory, focusing on ACRCloud credential wiring.
+
+ACRCloud credentials are read from the environment (``TRACKLISTIFY_ACR_*``),
+not the config dataclass. The factory must pass them to the provider and fail
+with a clear error when they are missing (rather than a cryptic ``TypeError``).
+"""
+
+import pytest
+
+from tracklistify.core.exceptions import ProviderError
+from tracklistify.providers.factory import ProviderFactory
+
+
+@pytest.fixture(autouse=True)
+def _clear_acr_env(monkeypatch):
+    """Ensure ACRCloud env vars never bleed in from a local .env."""
+    monkeypatch.delenv("TRACKLISTIFY_ACR_ACCESS_KEY", raising=False)
+    monkeypatch.delenv("TRACKLISTIFY_ACR_ACCESS_SECRET", raising=False)
+    monkeypatch.delenv("TRACKLISTIFY_ACR_HOST", raising=False)
+
+
+class TestACRCloudFactory:
+    def test_missing_credentials_raise_clear_error(self):
+        factory = ProviderFactory()
+        with pytest.raises(ProviderError, match="ACRCloud"):
+            factory.get_identification_provider("acrcloud")
+
+    def test_partial_credentials_raise_clear_error(self, monkeypatch):
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_KEY", "key123")
+        factory = ProviderFactory()
+        with pytest.raises(ProviderError, match="ACRCloud"):
+            factory.get_identification_provider("acrcloud")
+
+    def test_constructs_with_env_credentials(self, monkeypatch):
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_KEY", "key123")
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_SECRET", "secret123")
+        factory = ProviderFactory()
+        provider = factory.get_identification_provider("acrcloud")
+        assert provider.access_key == "key123"
+        # The provider encodes the secret to bytes in __init__.
+        assert provider.access_secret == b"secret123"
+
+    def test_host_override(self, monkeypatch):
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_KEY", "key123")
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_SECRET", "secret123")
+        monkeypatch.setenv("TRACKLISTIFY_ACR_HOST", "identify-us-west-2.acrcloud.com")
+        factory = ProviderFactory()
+        provider = factory.get_identification_provider("acrcloud")
+        assert provider.host == "identify-us-west-2.acrcloud.com"
+
+    def test_provider_is_cached(self, monkeypatch):
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_KEY", "key123")
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_SECRET", "secret123")
+        factory = ProviderFactory()
+        first = factory.get_identification_provider("acrcloud")
+        second = factory.get_identification_provider("acrcloud")
+        assert first is second
+
+    def test_unknown_provider_raises(self):
+        factory = ProviderFactory()
+        with pytest.raises(ValueError, match="Unknown provider"):
+            factory.get_identification_provider("does-not-exist")

--- a/tests/test_providers_acrcloud.py
+++ b/tests/test_providers_acrcloud.py
@@ -97,3 +97,30 @@ async def test_invalid_json_raises_provider_error(provider, monkeypatch):
     _patch_session(provider, monkeypatch, _FakeResponse(200, "not-json"))
     with pytest.raises(ProviderError, match="parse"):
         await provider.identify_track(b"audio-bytes")
+
+
+@pytest.mark.asyncio
+async def test_accepts_audio_segment_reading_file(provider, monkeypatch, tmp_path):
+    """identify_track must accept an AudioSegment (protocol used by the loop)."""
+    from types import SimpleNamespace
+
+    seg_file = tmp_path / "seg.wav"
+    seg_file.write_bytes(b"RIFFfake-audio")
+    segment = SimpleNamespace(file_path=str(seg_file), start_time=42)
+
+    captured = {}
+
+    def fake_prepare(audio_data, start_time):
+        captured["audio_data"] = audio_data
+        captured["start_time"] = start_time
+        return {"data": {}}
+
+    monkeypatch.setattr(provider, "_prepare_request_data", fake_prepare)
+    body = '{"status": {"code": 1001, "msg": "No result"}}'
+    _patch_session(provider, monkeypatch, _FakeResponse(200, body))
+
+    result = await provider.identify_track(segment)
+
+    assert captured["audio_data"] == b"RIFFfake-audio"
+    assert captured["start_time"] == 42
+    assert result["metadata"]["music"] == []

--- a/tests/test_providers_acrcloud.py
+++ b/tests/test_providers_acrcloud.py
@@ -1,0 +1,99 @@
+"""Tests for ACRCloudProvider.identify_track response handling.
+
+The provider only became reachable once the factory was fixed to pass
+credentials, so these lock in the response-parsing and error-mapping behavior.
+The HTTP session is mocked; no network is touched.
+"""
+
+import pytest
+
+from tracklistify.providers.acrcloud import ACRCloudProvider
+from tracklistify.providers.base import (
+    AuthenticationError,
+    ProviderError,
+    RateLimitError,
+)
+
+
+class _FakeResponse:
+    def __init__(self, status: int, text: str):
+        self.status = status
+        self._text = text
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *exc):
+        return False
+
+    async def text(self) -> str:
+        return self._text
+
+
+class _FakeSession:
+    def __init__(self, response: _FakeResponse):
+        self._response = response
+
+    def post(self, *args, **kwargs):
+        return self._response
+
+
+@pytest.fixture
+def provider():
+    return ACRCloudProvider("access-key", "access-secret")
+
+
+def _patch_session(provider, monkeypatch, response: _FakeResponse):
+    async def _get_session():
+        return _FakeSession(response)
+
+    monkeypatch.setattr(provider, "_get_session", _get_session)
+
+
+@pytest.mark.asyncio
+async def test_successful_identification(provider, monkeypatch):
+    body = (
+        '{"status": {"code": 0, "msg": "Success"}, '
+        '"metadata": {"music": [{"title": "Song", '
+        '"artists": [{"name": "Artist"}], "score": 95}]}}'
+    )
+    _patch_session(provider, monkeypatch, _FakeResponse(200, body))
+
+    result = await provider.identify_track(b"audio-bytes")
+
+    assert result["status"]["code"] == 0
+    music = result["metadata"]["music"]
+    assert len(music) == 1
+    assert music[0]["title"] == "Song"
+    assert music[0]["score"] == 95.0
+
+
+@pytest.mark.asyncio
+async def test_no_result_code_maps_to_empty_music(provider, monkeypatch):
+    body = '{"status": {"code": 1001, "msg": "No result"}}'
+    _patch_session(provider, monkeypatch, _FakeResponse(200, body))
+
+    result = await provider.identify_track(b"audio-bytes")
+
+    assert result["metadata"]["music"] == []
+
+
+@pytest.mark.asyncio
+async def test_http_401_raises_authentication_error(provider, monkeypatch):
+    _patch_session(provider, monkeypatch, _FakeResponse(401, ""))
+    with pytest.raises(AuthenticationError):
+        await provider.identify_track(b"audio-bytes")
+
+
+@pytest.mark.asyncio
+async def test_http_429_raises_rate_limit_error(provider, monkeypatch):
+    _patch_session(provider, monkeypatch, _FakeResponse(429, ""))
+    with pytest.raises(RateLimitError):
+        await provider.identify_track(b"audio-bytes")
+
+
+@pytest.mark.asyncio
+async def test_invalid_json_raises_provider_error(provider, monkeypatch):
+    _patch_session(provider, monkeypatch, _FakeResponse(200, "not-json"))
+    with pytest.raises(ProviderError, match="parse"):
+        await provider.identify_track(b"audio-bytes")


### PR DESCRIPTION
## Summary

A deep-dive code review (core orchestration, providers, rate limiter, cache, downloaders, exporters) followed by a focused, low-risk refactor. Changes split into three themes across three commits.

**376 tests pass** (8 new), `ruff check` + `ruff format` clean, no new `vulture` findings.

### `perf:` lightweight cleanups (behavior-preserving)
- **O(n) track dedup** — `TrackMatcher.get_unique_tracks` replaced an O(n²) linear-scan + `list.remove` + double-sort with a single dict pass + one sort. Tie-breaking (earliest-wins among equal confidence, highest-confidence selection) preserved.
- **Cache size reuse** — `SizeStrategy.update_metadata` no longer re-serializes the value via `json.dumps` on every access; it reuses the size computed at set-time.
- **Shazam cooldown** hoisted out of the per-segment hot path into `__init__`.
- `MIN_SEGMENT_FILE_SIZE` constant instead of the literal `1000`; precompiled exporter sanitization regexes; removed unused `get_ydl_opts()`; parallelized Spotify `get_track_details` with `asyncio.gather`.

### `fix:` two latent crash-on-use bugs
- **ACRCloud factory** — `ACRCloudProvider()` was constructed with no args, raising `TypeError` the moment `acrcloud` was selected. Now reads `TRACKLISTIFY_ACR_ACCESS_KEY` / `_ACCESS_SECRET` (and optional `_HOST`) from the environment (the documented design) and raises a clear `ProviderError` when missing.
- **Spotify downloader** — `_set_metadata` called `asyncio.run()` while already inside the running `download()` event loop, raising `RuntimeError` whenever a track had cover art. Made `_set_metadata` async and `await`s the cover fetch.

### `feat:` circuit-breaker wiring + bounded metrics
- The circuit breaker was implemented but **never called in production** (only from tests), so `circuit_state` never opened. The identification loop now reports each provider request outcome (a `None`/no-match result still counts as success; an exception is a failure), so repeated provider failures trip the breaker and stop hammering it. Remains config-gated via `circuit_breaker_enabled` (default threshold 5, 60s reset).
- Bounded `rate_limit_windows` to `MAX_RATE_LIMIT_WINDOWS` so long-running processes don't grow the metrics list without bound.

## Tests
- New `tests/test_provider_factory.py` — ACRCloud credential wiring (missing/partial creds raise, env creds construct, host override, caching, unknown provider).
- New `tests/test_identification_circuit_breaker.py` — breaker trips after repeated failures (and stops calling the provider); `record_result` resets the failure streak on success.

## Notes / out of scope
- Offloading the synchronous `mutagen` probe to a thread was considered but reverted: `split_audio` is synchronous and making it async would ripple into callers/tests — too much regression surface for an optional item.
- Parallelizing the main per-segment identification loop was deliberately excluded (interacts with rate limiter, Shazam cooldown, ordering, and circuit-breaker state).
- Pre-existing `ruff format` drift in unrelated files (`cli.py`, `test_error_handling.py`, `test_logger.py`) was left untouched.

