### PR TITLE
fix: handoff audit — enforce config validation, repair broken provider paths, add guardrails

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -67,9 +67,16 @@ TRACKLISTIFY_DOWNLOAD_MAX_RETRIES=3
 
 # --- API credentials (do NOT commit real values) ------------------------
 # These are read directly by provider modules via os.getenv, not via the
-# dataclass. They are listed here for completeness.
+# dataclass (secrets are deliberately kept off the config dataclass so they
+# can't leak through repr() or validation error messages).
+#
+# Required for `--provider acrcloud` (providers/factory.py reads these):
 # TRACKLISTIFY_ACR_ACCESS_KEY=
 # TRACKLISTIFY_ACR_ACCESS_SECRET=
+# TRACKLISTIFY_ACR_HOST=identify-eu-west-1.acrcloud.com
+#
+# Spotify credentials: currently consumed only by the UNWIRED Spotify
+# downloader/exporter (see docs/BACKLOG.md); not needed for normal runs.
 # TRACKLISTIFY_SPOTIFY_CLIENT_ID=
 # TRACKLISTIFY_SPOTIFY_CLIENT_SECRET=
 # TRACKLISTIFY_SPOTIFY_COOKIES=~/.mozilla/firefox/profile/cookies.sqlite

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,63 @@
+# CI for tracklistify.
+#
+# This is the enforcement layer for the invariants documented in
+# docs/ARCHITECTURE.md. Pre-commit hooks only run on machines where they're
+# installed; this workflow is what actually gates merges. Keep the four jobs
+# in sync with the local commands in CLAUDE.md:
+#   lint    -> uv run ruff check src/ tests/ scripts/
+#   format  -> uv run ruff format --check src/ tests/ scripts/
+#   drift   -> uv run python scripts/generate_env_example.py --check
+#   test    -> uv run python -m pytest -q   (3.11 / 3.12 / 3.13)
+
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  lint:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync --dev
+      - name: Ruff lint
+        run: uv run ruff check src/ tests/ scripts/
+      - name: Ruff format check
+        run: uv run ruff format --check src/ tests/ scripts/
+
+  drift:
+    # .env.example is generated; hand-edits or new config fields that aren't
+    # mapped to a section fail here instead of silently drifting.
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: "3.12"
+      - run: uv sync
+      - name: .env.example is in sync with TrackIdentificationConfig
+        run: uv run python scripts/generate_env_example.py --check
+
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: ["3.11", "3.12", "3.13"]
+    steps:
+      - uses: actions/checkout@v4
+      - name: Install ffmpeg (required by the audio pipeline + some tests)
+        run: sudo apt-get update && sudo apt-get install -y --no-install-recommends ffmpeg
+      - uses: astral-sh/setup-uv@v5
+        with:
+          python-version: ${{ matrix.python-version }}
+      - run: uv sync --dev
+      # `uv run python -m pytest`, NOT `uv run pytest`: an ambient pytest can
+      # shadow the venv's and silently change asyncio strict-mode behavior.
+      - name: Run tests
+        run: uv run python -m pytest -q

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -14,11 +14,16 @@ Stack: Python 3.11–3.13, `uv` package manager, `pytest` (asyncio strict), `ruf
 | **Run tests** | `uv run python -m pytest -q` |
 | Run one test | `uv run python -m pytest tests/test_x.py::test_y -v` |
 | Coverage | `uv run python -m pytest --cov=tracklistify --cov-report=html tests/` |
-| Lint | `uv run ruff check src/ tests/` |
-| Format | `uv run ruff format src/ tests/` |
-| Format check | `uv run ruff format --check src/ tests/` |
+| Lint | `uv run ruff check src/ tests/ scripts/` |
+| Format | `uv run ruff format src/ tests/ scripts/` |
+| Format check | `uv run ruff format --check src/ tests/ scripts/` |
 | Run CLI | `uv run tracklistify <input>` |
 | Dead-code scan | `uv run vulture src/tracklistify` |
+| Regenerate `.env.example` | `uv run python scripts/generate_env_example.py` (`--check` in CI) |
+
+CI (`.github/workflows/ci.yml`) runs lint, format check, the `.env.example`
+drift check, and the test suite on Python 3.11–3.13. Keep it in sync with
+this table.
 
 **Always use `uv run python -m pytest`, not bare `pytest`.** A pyenv-ambient pytest 7.x will shadow the venv's pytest 8.x and silently break async-mode strict.
 
@@ -29,8 +34,8 @@ Stack: Python 3.11–3.13, `uv` package manager, `pytest` (asyncio strict), `ruf
 - **`uv run pytest` picks up pyenv's pytest 7.4** instead of the venv's 8.x — always `uv run python -m pytest`.
 - **`get_config()` is a module-level singleton.** Tests that mutate env must call `get_config(force_refresh=True)` *and* `monkeypatch.delenv("TRACKLISTIFY_*", raising=False)` for any vars they don't want bleeding in from local `.env`.
 - **Providers are async context managers.** Always `async with provider:` — bare `with` silently breaks cleanup.
-- **Rate-limiter release in `finally`.** `await limiter.acquire(...)` must always be matched by `limiter.release(provider)` or tokens leak.
-- **Logger naming:** `get_logger(__name__)` — never a literal module string. The package logger config inspects `__name__` for per-module level overrides.
+- **Rate-limiter release in `finally`.** `await limiter.acquire(...)` must always be matched by `limiter.release(provider)` or tokens leak. Report request outcomes via `limiter.record_result(provider, success)` or the circuit breaker never learns and never opens.
+- **Logger naming:** `get_logger(__name__)` — never a literal module string, so log lines attribute to the right module and the third-party noise caps (symphonia) stay scoped.
 - **Singletons are thread-safe via `threading.Lock`.** Don't add a parallel lock for "extra safety"; double-checked locking is already in place (`get_config`, cache factory, `get_global_rate_limiter`).
 - **`audioop-lts` is the 3.13 dep.** PEP 594 removed stdlib `audioop`; `pyproject.toml` has the conditional `python_version >= '3.13'` marker. Pydub imports `audioop` directly, so the shim is required.
 - **Ruff `include` path is `src/tracklistify/**/*.py`** (not `tracklistify/**/*.py`). Wrong glob silently lints zero files — burned us once.
@@ -39,6 +44,10 @@ Stack: Python 3.11–3.13, `uv` package manager, `pytest` (asyncio strict), `ruf
 - **Spotify `_api_request` accepts any 2xx and handles 204.** Don't narrow to `== 200`; mutation endpoints return 201, DELETEs return 204 with empty body.
 - **Spotify wrappers must re-raise `RateLimitError` / `AuthenticationError` unchanged.** Catch them before the generic `except Exception` or callers lose retry-after timing and 401-driven token refresh.
 - **`--stream-copy` (`-sc`) keeps the source codec end-to-end.** yt-dlp skips its MP3 transcode and segments stream-copy whatever YouTube served (opus/webm or m4a). Shazamio decodes via pydub/ffmpeg so any format works; ACRCloud historically prefers MP3 — if identification rates drop with `-sc` + ACRCloud, drop the flag for that run.
+- **Provider secrets are env-only, never config-dataclass fields** — keeps them out of `repr()` and validation error messages. ACRCloud: `TRACKLISTIFY_ACR_ACCESS_KEY`/`_SECRET` (+ optional `_HOST`), read in `providers/factory.py`. Follow this pattern for new providers.
+- **`config.min_confidence` (0–1) and `Track.confidence` (0–100) are different scales**, and the config knob is currently a deliberate no-op (`TrackMatcher` hardcodes 0). Read docs/BACKLOG.md P2 before wiring it.
+- **The cache subsystem is NOT wired into the pipeline.** `cache_enabled` changes nothing today; internals were made safe (TTL, index persistence) in the 2026-07 audit. Wiring plan: docs/BACKLOG.md P1.
+- **`tests/test_handoff_invariants.py` locks the load-bearing invariants** (validation enforced, positive segmentation step, provider constructibility, fallback chain, circuit-breaker wiring, cache TTL/index persistence). If one fails, read docs/ARCHITECTURE.md before "fixing" the test.
 
 ---
 
@@ -92,9 +101,16 @@ Don't commit unless explicitly asked. When asked, use heredoc commit messages fo
 
 ## Doing common tasks
 
-- **Add a provider:** subclass `TrackIdentificationProvider` from `providers/base.py`, register in `providers/factory.py::get_identification_provider`, add config fields to `TrackIdentificationConfig`, add tests with mocked `_api_request`.
-- **Add an output format:** add a method to `exporters/tracklist.py::TracklistOutput`, wire it into `save_all`, extend the `cli.py` `--formats` choices.
-- **Add a config option:** add a field to `TrackIdentificationConfig` (`config/base.py`) with a default; add validation in `__post_init__` if it has bounds; assign the field to a section in `scripts/generate_env_example.py::FIELD_SECTIONS`; run `uv run python scripts/generate_env_example.py` to refresh `.env.example`.
+**Follow `docs/PLAYBOOKS.md`** — it has the full step-by-step procedures with
+the traps spelled out (add a provider, add a config option, add an output
+format, touch split_audio / rate limiter / config loading, debug "no tracks
+identified"). The load-bearing map and landmines are in
+`docs/ARCHITECTURE.md`; known debt in `docs/BACKLOG.md`.
+
+Quick reminders (the playbooks have the detail):
+- **Provider:** `identify_track` takes an `AudioSegment` (not bytes), returns score on 0–100, registers in `KNOWN_PROVIDERS`; missing creds → `ConfigError` naming the env vars.
+- **Config option:** must be assigned in `generate_env_example.py::FIELD_SECTIONS` (CI drift job fails otherwise) — and something must actually *read* the field, or don't add it.
+- **Output format:** method on `TracklistOutput`, wire into `save()` + `save_all()`, extend `--formats` choices.
 
 For everything else, read the surrounding code — it's the source of truth, not this file.
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,141 @@
+# Architecture & Handoff Map
+
+Written during the 2026-07 handoff audit. This is the mental model of the
+system: what carries load, what assumptions the code makes without checking,
+and where the landmines are. Read this before changing anything under
+`src/tracklistify/`. Recurring change procedures live in
+[PLAYBOOKS.md](PLAYBOOKS.md); known debt lives in [BACKLOG.md](BACKLOG.md).
+
+## The pipeline in one paragraph
+
+`tracklistify <input>` → `cli.py::cli()` parses args, checks ffmpeg exists,
+loads `.env`, then `asyncio.run(main(args))` → `AsyncApp.process_input()`:
+validate the input (`utils/validation.py::validate_input` — URL or local
+file), download via `DownloaderFactory` (yt-dlp for YouTube/SoundCloud,
+Mixcloud variant) into a per-run temp dir, slice into overlapping segments
+with ffmpeg stream-copy (`AsyncApp.split_audio`, thread pool), identify each
+segment via `IdentificationManager.identify_tracks` (provider chain with
+rate limiting + circuit breaker), dedup via `TrackMatcher`, write
+json/markdown/m3u via `TracklistOutput`, clean up the temp dir.
+
+## Load-bearing inventory (ranked by blast radius)
+
+| # | Component | Why it's load-bearing |
+|---|---|---|
+| 1 | `core/base.py::AsyncApp.process_input` | The only orchestration path. Every run goes through it. |
+| 2 | `utils/identification.py::IdentificationManager.identify_tracks` | Provider chain, rate-limiter acquire/release pairing, circuit-breaker reporting. Break the release pairing and every run deadlocks after N segments. |
+| 3 | `config/base.py` + `config/factory.py::get_config` | Module-level singleton. Everything reads config from here; many objects capture it at construction. |
+| 4 | `core/base.py::split_audio` | ffmpeg segmentation. The `step = segment_length - overlap_duration` arithmetic MUST stay positive (guarded twice: config validation + a runtime check here). |
+| 5 | `utils/rate_limiter.py::RateLimiter` | Token bucket + semaphore + circuit breaker. `acquire()` must always be paired with `release()` in a `finally`. |
+| 6 | `core/track.py::Track` / `TrackMatcher` | Track validation (`__post_init__`) and dedup. Output quality lives here. |
+| 7 | `providers/factory.py` | Provider name → instance. `KNOWN_PROVIDERS` is the registry; invariant test I3 keeps every entry constructible. |
+| 8 | `providers/shazam.py` | The only provider that works with zero setup; the default path virtually every user takes. |
+| 9 | `downloaders/ytdlp.py` | All YouTube/SoundCloud input. Requires ffmpeg and (for YouTube) Deno for yt-dlp-ejs challenge solving. |
+| 10 | `exporters/tracklist.py` | The only output path (`save_all` / `save`). |
+
+## Invariants (each is locked by `tests/test_handoff_invariants.py`)
+
+- **I1** Config validation rules run at construction (`BaseConfig._validate`
+  feeds dataclass fields to `ConfigValidator`). This was dead code until
+  2026-07 — the rules were registered and never executed.
+- **I2** `segment_length - overlap_duration > 0`, enforced at config load
+  AND at the top of `split_audio` (config attributes are mutable after
+  load — CLI overrides mutate them — so the config-time check alone is
+  insufficient). Violation = infinite while-loop.
+- **I3** Every name in `providers.factory.KNOWN_PROVIDERS` constructs via
+  the factory or raises `ConfigError` naming the env vars to set. Never a
+  bare `TypeError`.
+- **I4** Providers take an `AudioSegment` (object with `file_path`) in
+  `identify_track` and return `{"metadata": {"music": [{title, artists,
+  score}]}}` with score on a **0–100** scale, or `None`/empty music list
+  for no-match.
+- **I5** Fallback: `fallback_providers` are tried in order only when
+  `fallback_enabled` is true and the primary yielded no usable track.
+- **I6** Every provider request outcome is reported to
+  `RateLimiter.record_result` so the circuit breaker actually learns.
+- **I7/I8** Cache TTL expiry works and the cache index is persisted on
+  every mutation. (The cache is still NOT wired into the pipeline — see
+  landmine below.)
+
+## Implicit contracts (assumed, not checked — tread carefully)
+
+- `limiter.acquire(name)` / `limiter.release(name)` are paired per name,
+  release in `finally`, and `release` is only called when `acquire`
+  returned True. `acquire` itself releases its semaphore on all
+  non-True exits.
+- Providers are async context managers; `close()` must be re-entrable
+  (the factory caches instances and `close_all()` may close them again).
+  ACRCloud/Spotify recreate their aiohttp session lazily after close.
+- `split_audio` returns segments sorted by `start_time`; identification
+  and the "time in mix" output depend on that ordering.
+- `Track.time_in_mix` is **elapsed** `H+:MM:SS` (hours unbounded, so a
+  25-hour mix offset parses); never use `strptime("%H:%M:%S")` on it.
+- `get_config()` is process-wide. Objects capture it at construction, so
+  "refresh" only affects objects created afterwards. Tests must use
+  `get_config(force_refresh=True)` *and* clear `TRACKLISTIFY_*` env vars.
+- Confidence is 0–100 on `Track`, but `config.min_confidence` is 0.0–1.0.
+  **These scales are different.** See landmine below.
+- Segment filenames encode `start_time` and live in a per-run temp subdir
+  named `<pid>-<hex8>`; the stale-dir sweeper (`_sweep_stale_run_dirs`)
+  assumes that shape and kills only dirs whose PID is dead.
+
+## Landmines (non-obvious, will bite)
+
+1. **`config.min_confidence` is currently NOT applied.**
+   `TrackMatcher.__init__` hardcodes `_min_confidence = 0` ("keep all
+   tracks"). This appears deliberate (commit 2a37054-era behavior), so the
+   audit did not change it, but it means the documented config knob is a
+   no-op AND its unit (0–1) differs from Track confidence (0–100). If you
+   wire it up: `self._min_confidence = config.min_confidence * 100`, and
+   expect output to shrink. Decide, don't drift — see BACKLOG P2.
+2. **The cache subsystem (`cache/`, ~1600 lines) is not wired into any
+   production path.** Nothing calls `get_cache()` outside tests. Internal
+   data-loss bugs (TTL disabled, index never persisted) were fixed in the
+   2026-07 audit so it is now *safe* to wire, but identification results
+   are still re-fetched on every run. Wiring plan in BACKLOG P1.
+3. **`downloaders/spotify.py` and `exporters/spotify.py` are dead ends.**
+   No factory routes Spotify URLs, and the exporter needs a user-auth
+   token while `SpotifyProvider` only does client-credentials (which can
+   never call `/me/*` endpoints — playlist creation would 401). Don't
+   "just wire them up"; the auth model is wrong. BACKLOG P2/P3.
+4. **Secrets live in env vars, not the config dataclass** — deliberately,
+   so `repr(config)` and validation errors can't leak them. ACRCloud creds:
+   `TRACKLISTIFY_ACR_ACCESS_KEY` / `_SECRET` / optional `_HOST`, read in
+   `providers/factory.py`. Follow that pattern for new providers.
+5. **Provider instances are cached and shared** (`ProviderFactory.providers`
+   dict, module-level factory singleton). A provider that keeps per-run
+   state would leak it across runs in long-lived processes.
+6. **`get_root()` falls back to CWD when installed as a package** (no
+   pyproject.toml above `site-packages`), and it's captured at import time
+   as `BaseConfig.project_root`. Installed CLI users get `.tracklistify/*`
+   under whatever directory they launched from. Env override:
+   `TRACKLISTIFY_PROJECT_ROOT`.
+7. **Env parsing strips `#` comments** (`_load_from_env` splits on `#`).
+   A secret containing `#` set via a dataclass-backed env var would be
+   truncated. Credentials avoid this (read raw via `os.getenv`), but keep
+   it in mind for new string fields.
+8. **shazamio decodes via pydub/ffmpeg** — a missing ffmpeg breaks
+   identification too, not just segmentation. `cli()` fail-fasts on this;
+   don't remove that check.
+
+## "If you touch X, also update Y" couplings
+
+| You changed | You must also |
+|---|---|
+| Added/removed a field on `TrackIdentificationConfig` | Add it to a section in `scripts/generate_env_example.py::FIELD_SECTIONS`, run the script (CI `drift` job fails otherwise); add a range/type rule in `_setup_validation` if it has bounds. |
+| Added a provider | Update `providers/factory.py` (branch + `KNOWN_PROVIDERS`), rate limits in `RateLimiter.register_provider` + config fields, `.env.example` credentials block if it needs secrets, and the I3 invariant test will then cover it. Full procedure in PLAYBOOKS.md. |
+| Changed provider response shape | `IdentificationManager._track_from_info` is the single parse point; keep score 0–100. |
+| Renamed/moved a CLI flag | `tests/test_cli_arguments.py` and README examples. |
+| Changed segment naming or temp-dir layout | `_sweep_stale_run_dirs` (PID parsing) and `cleanup()`. |
+| Changed `pre-commit` hooks or commands | Mirror in `.github/workflows/ci.yml` and CLAUDE.md's command table. |
+
+## What the architecture gets right (don't "fix" these)
+
+- Segmentation stream-copies (`-c:a copy`) instead of re-encoding — that's
+  why splitting a 2-hour mix takes seconds. Don't add a transcode step.
+- `-ss` before `-i` in the ffmpeg command is an input-seek; moving it after
+  `-i` makes each segment decode from the file start (quadratic total work).
+- Rate limiter uses `asyncio.Lock`/`Semaphore`, not threading primitives —
+  the identify loop runs on the event loop and must not block it.
+- Singletons use double-checked locking with `threading.Lock`; don't add a
+  second layer of locking.

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -1,0 +1,137 @@
+# Residual Risk Register & Backlog
+
+From the 2026-07 handoff audit. Ordered by priority. Each item has enough
+context to be picked up cold. "Fixed" items are listed at the bottom so
+nobody re-audits them from scratch.
+
+## P1 — wire the cache into identification
+
+**What:** `cache/` (~1600 lines, tested, config-backed) is not called by any
+production code. Every run re-queries Shazam for every segment, even on
+reruns of the same file. `cache_enabled=true` in config is currently a no-op.
+
+**Why it's safe now:** the two data-loss bugs that made wiring dangerous were
+fixed in this audit (TTL-None disabling expiry; index never persisted →
+entries invisible cross-process and then deleted as "orphans" by cleanup).
+Invariant tests I7/I8 lock both.
+
+**How:** in `IdentificationManager.identify_tracks`, before the provider
+loop for a segment:
+1. `key = f"{provider_name}:{sha256(segment file bytes)}"` (hash the bytes,
+   not the path — temp paths are per-run).
+2. `cached = await cache.get(key)`; on hit, feed it to `_track_from_info`.
+3. On provider success, `await cache.set(key, track_info)`.
+4. Cache failures must degrade to identification, never abort the run
+   (`try/except` around both get and set, log at debug).
+Gate on `config.cache_enabled`. Add tests mirroring the fallback tests'
+stub pattern.
+
+**Remaining internal debt (fix opportunistically, don't block wiring):**
+`SizeStrategy` treats the whole-cache byte budget as a per-entry limit and
+nothing enforces aggregate size (no eviction); compression detection sniffs
+zlib magic bytes instead of using the stored `compression` flag (breaks if
+anyone wires `cache_compression_level` ≠ 6); `BaseCache.get()` rewrites the
+entry file on every hit (write amplification); `_stats["entries"]`
+over-counts overwrites.
+
+## P2 — decide `min_confidence` semantics
+
+`config.min_confidence` (0.0–1.0) is documented and validated but ignored:
+`TrackMatcher` hardcodes 0. Options:
+- (a) Wire it: `TrackMatcher.__init__` sets `self._min_confidence =
+  config.min_confidence * 100`. Behavior change: default 0.5 would drop
+  sub-50% matches — decide whether the default should become 0.0 to
+  preserve current output.
+- (b) Remove the field and its env var.
+Recommendation: (a) with default lowered to 0.0, so the knob works but
+nothing changes until a user turns it.
+
+## P2 — Spotify enrichment is built but unreachable
+
+`SpotifyProvider` (search/enrich, client-credentials auth) works but no
+pipeline stage calls `enrich_metadata`. The natural hook: after
+`TrackMatcher.get_unique_tracks()` in `identify_tracks`, enrich each track's
+`metadata` dict when Spotify creds are configured. Keep it strictly optional
+(no creds → skip silently).
+
+`exporters/spotify.py` (playlist export) is a different story: it calls
+`/me/playlists`, which client-credentials tokens can NEVER access. Wiring it
+requires implementing the authorization-code flow (user consent, token
+refresh). Don't attempt as a drive-by; it's a feature project.
+
+## P3 — delete or rescue `downloaders/spotify.py`
+
+Dead (no factory route) and internally broken: `asyncio.run()` inside a
+running loop (`_set_metadata`), enum-vs-string filename bug, and
+`_get_stream_url` is called with a track id where a file id is expected.
+Deleting ~400 lines + adjusting `test_imports.py`/`test_type_hints.py` is
+the cheap option; rescuing it means rewriting its download flow against a
+Spotify CDN API that may not be stable. Recommendation: delete.
+
+## P3 — dev_cli cleanup
+
+- `dev_cli/execution/executor.py` is unused (commands use `subprocess.run`
+  directly); its timeout parameter is also never enforced. Delete.
+- `dev_cli/config.py`: missing `tools.json` crashes at import (the
+  `FileNotFoundError` fallback can never fire because a manual
+  `ConfigurationError` is raised first); `load_default_config()` is called
+  redundantly after construction.
+- `RunCommand._run_tool` joins args into a string then re-splits with
+  shlex — args containing spaces/quotes get mangled.
+
+## P3 — config/docs.py accuracy
+
+The doc generator works now (`scripts/generate_config_docs.py` was calling
+a method that never existed; fixed), but: `_field_to_schema` parses
+constraint strings like "Must be >= 10" by inspecting the wrong token, so
+min/max never reach the JSON schema; `generate_schema` marks every field
+required; `field.__doc__` is the `dataclasses.Field` class docstring, not a
+field description. Low value — consider generating from
+`_setup_validation` rules directly instead of parsing prose.
+
+## P3 — security polish
+
+- `mask_sensitive_value` reveals first/last 3 chars of secrets ≥ 8 chars;
+  an 8-char secret leaks 6/8 characters. Raise the full-mask threshold to
+  ~12.
+- Two divergent sensitivity predicates (`is_sensitive_key` vs
+  `is_sensitive_field`) — currently consistent, fragile on divergence.
+  Collapse to one.
+- `cache/storage.py` trusts `filename` from the on-disk index without a
+  basename check; a tampered index could point delete/read at arbitrary
+  paths. Add `os.path.basename(filename) == filename` validation on load.
+
+## P4 — misc
+
+- `utils/decorators.py::memoize` has an unused `ttl` param and unbounded
+  growth, and no callers. Delete or finish.
+- `core/types.py` declares a `Downloader` Protocol incompatible with the
+  real `downloaders/base.py` ABC (different signature/return). Delete the
+  Protocol.
+- `core/run.py` cleanup-task registry is never populated; `ACRCLOUD_SUCCESS_CODE = 2000`
+  in constants is actually ACRCloud's *auth error* code and is unused.
+- `tests/test_cli_arguments.py` uses an unregistered `integration` pytest
+  mark (warning noise); register it in pyproject or drop it.
+- `pytest-asyncio` will eventually require `asyncio_default_fixture_loop_scope`;
+  set it explicitly in `[tool.pytest.ini_options]` when upgrading.
+
+---
+
+## Fixed in the 2026-07 audit (do not re-fix; locked by tests)
+
+| Fix | Where | Test |
+|---|---|---|
+| Config validation rules were never executed | `config/base.py::_validate` | I1 |
+| `overlap >= segment` → infinite segmentation loop | config cross-check + `split_audio` guard | I2 |
+| ACRCloud unconstructible (missing ctor args) + wrong `identify_track` signature | `providers/factory.py`, `providers/acrcloud.py` | I3, I4 |
+| `--no-fallback` / `fallback_*` config were no-ops | `IdentificationManager` provider chain | I5 |
+| Circuit breaker never received outcomes | `RateLimiter.record_result` + identify loop | I6 |
+| Cache TTL disabled by stored `None` | `cache/base.py::set` | I7 |
+| Cache index never saved on set/delete (cross-process data loss + orphan deletion of valid entries) | `cache/storage.py` | I8 |
+| Cache index rename without fsync | `cache/index.py::save` | — |
+| ffmpeg absence surfaced as cryptic per-segment errors | `cli.py` fail-fast + `split_audio` log | CLI tests |
+| `TracklistOutput` mkdir without `parents=True` | `exporters/tracklist.py` | — |
+| Spotify 429 lost structured `retry_after` | `providers/spotify.py` | — |
+| `cz bump` broken (`version_provider = "poetry"` post-uv-migration) | `pyproject.toml` | — |
+| `scripts/generate_config_docs.py` called a nonexistent method | fixed to use `ConfigDocGenerator` | — |
+| Dead + broken module-level `identify_tracks(audio_path)` (iterated a string as segments) | removed from `utils/identification.py` | — |

--- a/docs/PLAYBOOKS.md
+++ b/docs/PLAYBOOKS.md
@@ -1,0 +1,150 @@
+# Playbooks
+
+Step-by-step procedures for the recurring changes in this codebase. Follow
+them literally; each ends with the exact verification commands. The traps
+listed are real failures, not hypotheticals. Background/why lives in
+[ARCHITECTURE.md](ARCHITECTURE.md).
+
+Every playbook ends the same way:
+
+```bash
+uv run ruff check src/ tests/ scripts/ && uv run ruff format src/ tests/ scripts/
+uv run python -m pytest -q      # NOT `uv run pytest` — see CLAUDE.md
+```
+
+---
+
+## Add an identification provider
+
+1. Subclass `TrackIdentificationProvider` (`providers/base.py`) in a new
+   `providers/<name>.py`.
+   - `identify_track(audio_segment)` receives an `AudioSegment` (object
+     with `file_path`, `start_time`, `duration`). Read the file yourself
+     (use `await asyncio.to_thread(Path(...).read_bytes)` — file IO blocks
+     the event loop).
+   - Return `{"metadata": {"music": [{"title": str, "artists": [{"name":
+     str}], "score": float}]}}`. **Score must be 0–100**, not 0–1 — Track
+     construction rejects anything outside 0–100.
+   - Return `None` or an empty `music` list for "no match". Raise a
+     `ProviderError` subclass for real failures (this feeds the circuit
+     breaker; returning None on errors hides outages).
+   - Re-raise `RateLimitError` / `AuthenticationError` unchanged — never
+     let a generic `except Exception` swallow them.
+2. Register in `providers/factory.py::get_identification_provider`:
+   - Add a branch AND add the name to `KNOWN_PROVIDERS`.
+   - Credentials come from `os.getenv("TRACKLISTIFY_<NAME>_...")` — **not**
+     from config dataclass fields (secrets must stay out of `repr()` and
+     validation errors). Missing credentials must raise `ConfigError` with
+     a message naming the exact env vars (I3 test enforces this).
+3. Rate limits: add `<name>_max_rpm` / `<name>_max_concurrent` fields to
+   `TrackIdentificationConfig` with sane defaults, add a branch in
+   `RateLimiter.register_provider`, and map the fields to a section in
+   `scripts/generate_env_example.py`, then run the script.
+4. Document credentials in the `CREDENTIALS_BLOCK` of
+   `scripts/generate_env_example.py` and regenerate.
+5. Tests: mock the HTTP session (see
+   `tests/test_handoff_invariants.py::test_acrcloud_identify_accepts_audio_segment`
+   for the pattern). Never hit the network.
+6. Run `uv run python -m pytest tests/test_handoff_invariants.py -q` —
+   I3 picks up the new `KNOWN_PROVIDERS` entry automatically.
+
+**The trap:** implementing `identify_track(bytes)` instead of
+`identify_track(AudioSegment)`. That exact mismatch made ACRCloud dead on
+arrival for its entire life pre-2026-07. The pipeline passes segments.
+
+---
+
+## Add a config option
+
+1. Add the field to `TrackIdentificationConfig` (`config/base.py`) with a
+   default. The env var `TRACKLISTIFY_<UPPER_NAME>` works automatically.
+2. Bounds? Add a rule in `_setup_validation` (they ARE enforced now).
+   Cross-field constraint? Add it to `TrackIdentificationConfig._validate`
+   after `super()._validate()`.
+3. Assign the field to a section in
+   `scripts/generate_env_example.py::FIELD_SECTIONS` (the script — and the
+   CI `drift` job — hard-fails on unmapped fields). Add an
+   `INLINE_COMMENTS` entry for units/bounds.
+4. `uv run python scripts/generate_env_example.py`
+5. **Actually consume the field.** Grep for an existing consumer before
+   assuming; this codebase already shipped `min_confidence`,
+   `fallback_*` (pre-2026-07), `overlap_strategy`, `min_segment_length`,
+   and most `cache_*` fields as no-ops. A config option nobody reads is a
+   lie to the user — if you can't wire it now, don't add it.
+
+**The trap:** step 5. The env example and dataclass make an option *look*
+supported long before anything reads it.
+
+---
+
+## Add an output format
+
+1. Add `_save_<fmt>()` to `exporters/tracklist.py::TracklistOutput`,
+   returning the written `Path`.
+2. Wire it into `save()`'s dispatch and add the format to `save_all()`'s
+   list.
+3. Add the choice to the `--formats` argparse option in `cli.py` and to
+   the `output_format` inline comment in `generate_env_example.py`.
+4. Filenames must go through the existing `_format_filename` /
+   `clean_string` path — it strips path separators from titles (YouTube
+   titles are untrusted input).
+
+---
+
+## Touch `split_audio`
+
+- Keep the two guards: positive step, and ffmpeg-missing error.
+- Keep `-ss` **before** `-i` (input-seek; after `-i` = decode-from-start
+  per segment, quadratic total work).
+- Keep `-c:a copy`; re-encoding multiplies runtime by ~100x on long mixes.
+- Keep the final `segments.sort(key=...)` — `as_completed` yields out of
+  order and downstream assumes chronological order.
+- Segment filename shape `segment_<start>_<len><suffix>` inside
+  `self.temp_dir` (per-run dir); `cleanup()` and the stale-PID sweeper
+  depend on the dir layout.
+
+## Touch the rate limiter
+
+- Every code path out of `acquire()` after the semaphore is taken must
+  either return True or release the semaphore. Check the `except
+  BaseException` block still covers cancellation.
+- `record_result(provider, success)` is the only sanctioned way to feed
+  the circuit breaker from outside; keep the identification loop calling
+  it on both outcomes.
+- Only `asyncio` primitives inside acquire/release paths. A
+  `threading.Lock` held across an `await` will deadlock the event loop —
+  that bug was already fixed once (commit 86fa9fc); don't reintroduce it.
+
+## Touch config loading
+
+- Order in `__post_init__` is load-bearing:
+  `_load_from_env` → `_create_directories` → `_setup_validation` →
+  `_validate`. Validation must see env-loaded values; directory PathRules
+  must run after dirs exist (or use `create_if_missing`).
+- Tests mutating env: `monkeypatch.delenv("TRACKLISTIFY_*", ...)` first,
+  `get_config(force_refresh=True)` after. A developer's local `.env`
+  otherwise bleeds into CI-green-but-locally-red test failures.
+
+## Release / version bump
+
+- `cz bump` (commitizen) reads `[project].version` via
+  `version_provider = "pep621"`. Don't set it back to `"poetry"`; the
+  project migrated to uv and there is no `[tool.poetry]` table.
+
+## Debugging a 3am "no tracks identified" report
+
+Work down this list; each step has a distinct signature:
+
+1. **ffmpeg missing** → the CLI now refuses to start; if running via API,
+   look for the `ffmpeg not found on PATH` error log.
+2. **Download failed / wrong file** → check the `Downloaded audio to:` log
+   line and whether the file exists with nonzero size.
+3. **Segments empty** → `Split audio into 0 segments`; usually a corrupt
+   download or an ffmpeg build without the needed demuxer.
+4. **Provider errors on every segment** → `<provider> identification
+   failed for segment at Ns:` lines; check credentials (ACRCloud) or
+   upstream throttling (Shazam). Circuit breaker opening shows up as
+   `Rate limiter rejected request` after repeated failures.
+5. **Everything "no match"** → genuine content problem (unreleased music,
+   heavy overlays). Try `--provider acrcloud` (needs creds) or smaller
+   `TRACKLISTIFY_SEGMENT_LENGTH`.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -78,7 +78,10 @@ skips = []
 name = "cz_conventional_commits"
 tag_format = "v$version"
 version_scheme = "pep440"
-version_provider = "poetry"
+# pep621 reads [project].version above; the previous value ("poetry") looked
+# for [tool.poetry].version, which no longer exists since the uv migration —
+# `cz bump` was broken.
+version_provider = "pep621"
 update_changelog_on_bump = true
 major_version_zero = true
 changelog_start_rev = "v0.6.8"

--- a/scripts/generate_config_docs.py
+++ b/scripts/generate_config_docs.py
@@ -16,15 +16,24 @@ sys.path.append(str(project_root))
 
 def main():
     """Generate configuration documentation."""
+    # Lazy import here so the module docstring stays honest even if docs.py
+    # moves. The generator documents whatever rules _setup_validation
+    # registered on the live config instance.
+    from tracklistify.config.docs import ConfigDocGenerator
+
     config = get_config()
 
     # Generate documentation
     docs_dir = project_root / "docs"
     docs_dir.mkdir(exist_ok=True)
 
-    # Generate main configuration documentation
+    # Generate main configuration documentation from the config's own
+    # validator (config.generate_documentation never existed — this script
+    # crashed with AttributeError before this was wired up).
     output_file = docs_dir / "configuration.md"
-    documentation = config.generate_documentation(str(output_file))
+    generator = ConfigDocGenerator(config._validator)
+    documentation = generator.generate_markdown()
+    output_file.write_text(documentation, encoding="utf-8")
 
     # Also update .env.example with latest configuration
     env_example = project_root / ".env.example"

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -136,9 +136,16 @@ COMMENTED_OUT_FIELDS: set[str] = {"fallback_providers"}
 CREDENTIALS_BLOCK = """\
 # --- API credentials (do NOT commit real values) ------------------------
 # These are read directly by provider modules via os.getenv, not via the
-# dataclass. They are listed here for completeness.
+# dataclass (secrets are deliberately kept off the config dataclass so they
+# can't leak through repr() or validation error messages).
+#
+# Required for `--provider acrcloud` (providers/factory.py reads these):
 # TRACKLISTIFY_ACR_ACCESS_KEY=
 # TRACKLISTIFY_ACR_ACCESS_SECRET=
+# TRACKLISTIFY_ACR_HOST=identify-eu-west-1.acrcloud.com
+#
+# Spotify credentials: currently consumed only by the UNWIRED Spotify
+# downloader/exporter (see docs/BACKLOG.md); not needed for normal runs.
 # TRACKLISTIFY_SPOTIFY_CLIENT_ID=
 # TRACKLISTIFY_SPOTIFY_CLIENT_SECRET=
 # TRACKLISTIFY_SPOTIFY_COOKIES=~/.mozilla/firefox/profile/cookies.sqlite

--- a/src/tracklistify/cache/base.py
+++ b/src/tracklistify/cache/base.py
@@ -127,14 +127,19 @@ class BaseCache(Generic[T]):
             ):
                 raise TypeError("Cache value must be JSON serializable")
 
-            # Create entry with metadata
+            # Create entry with metadata.
+            # TTL: fall back to the cache-level TTL when the caller doesn't
+            # pass one. Storing a literal None here disabled expiry entirely:
+            # TTLStrategy does metadata.get("ttl", default_ttl), and a
+            # present-but-None key shadows the default, so is_valid always
+            # returned True. Locked by tests/test_handoff_invariants.py.
             entry: CacheEntry[T] = {
                 "key": key,
                 "value": value,
                 "metadata": {
                     "created": time.time(),
                     "last_accessed": time.time(),
-                    "ttl": ttl,
+                    "ttl": ttl if ttl is not None else self._ttl,
                     "compression": compression,
                     "size": len(json.dumps(value)),
                 },

--- a/src/tracklistify/cache/index.py
+++ b/src/tracklistify/cache/index.py
@@ -5,6 +5,7 @@ Cache index management for efficient key-to-filename mapping.
 # Standard library imports
 import asyncio
 import json
+import os
 import time
 import zlib
 from pathlib import Path
@@ -68,6 +69,10 @@ class CacheIndex:
                 async with aiofiles.open(temp_file, "w") as f:
                     await f.write(json.dumps(self._index, indent=2))
                     await f.flush()
+                    # fsync before rename, matching JSONStorage.set(): a
+                    # crash between flush and rename must not leave a
+                    # truncated index that load() then treats as corrupt.
+                    os.fsync(f.fileno())
 
                 # Atomic replace
                 temp_file.replace(self._index_file)

--- a/src/tracklistify/cache/storage.py
+++ b/src/tracklistify/cache/storage.py
@@ -135,6 +135,13 @@ class JSONStorage(CacheStorage[T]):
                 metadata["size"] = len(data)
                 await self._index.add_entry(key, filename, metadata)
 
+            # Persist the index NOW. It used to be saved only from
+            # cleanup()/clear(), so entries written by a process that
+            # exited normally were invisible to the next process (stale
+            # index -> reported misses) and then deleted as "orphans" by
+            # the next cleanup(). save() no-ops when the index is clean.
+            await self._index.save()
+
         except Exception as e:
             logger.error(f"Error writing cache entry: {str(e)}")
             # Clean up temp file only if it was created and still exists
@@ -159,6 +166,9 @@ class JSONStorage(CacheStorage[T]):
             async with self._get_lock(key):
                 if os.path.exists(file_path):
                     os.unlink(file_path)
+
+            # Persist the removal (see matching comment in set()).
+            await self._index.save()
         except Exception as e:
             logger.error(f"Error deleting cache entry: {str(e)}")
             raise

--- a/src/tracklistify/cli.py
+++ b/src/tracklistify/cli.py
@@ -2,6 +2,7 @@
 import argparse
 import asyncio
 import os
+import shutil
 import signal
 import sys
 from pathlib import Path
@@ -48,8 +49,7 @@ async def main(args: argparse.Namespace) -> int:
             logger.warning("Second interrupt — forcing exit")
             os._exit(130)
         logger.info(
-            "Received shutdown signal — cancelling "
-            "(press Ctrl+C again to force exit)"
+            "Received shutdown signal — cancelling (press Ctrl+C again to force exit)"
         )
         if main_task is not None and not main_task.done():
             main_task.cancel()
@@ -207,6 +207,17 @@ def cli() -> None:
 
     # Log at the start of the CLI function
     logger.info("Starting CLI")
+
+    # Fail fast with an actionable message: every pipeline stage (download
+    # post-processing, segmentation, shazamio decoding via pydub) needs
+    # ffmpeg. Without this check the failure surfaces much later as a
+    # cryptic per-segment subprocess error.
+    if shutil.which("ffmpeg") is None:
+        logger.error(
+            "ffmpeg is required but was not found on PATH. Install it first "
+            "(e.g. `apt install ffmpeg`, `brew install ffmpeg`) and re-run."
+        )
+        sys.exit(1)
 
     # Load environment variables first
     env_path = get_root() / ".env"

--- a/src/tracklistify/config/base.py
+++ b/src/tracklistify/config/base.py
@@ -124,18 +124,21 @@ class BaseConfig:
     def _validate(self) -> None:
         """Validate all configuration values against defined rules.
 
-        This is a template method that subclasses can override to add
-        custom validation logic beyond the declarative rules.
-        Called automatically during __post_init__ after _setup_validation.
-
-        Subclasses should call super()._validate() first, then add
-        any additional validation that can't be expressed as rules.
+        This is a template method: it runs every rule registered in
+        ``_setup_validation`` against the dataclass fields. Subclasses
+        should call ``super()._validate()`` first, then add any
+        cross-field validation that can't be expressed as a single-field
+        rule.
 
         Raises:
-            ValueError: If any configuration value is invalid.
+            ValidationError: If any configuration value violates a rule.
         """
-        # Base class validation is handled by _validator
-        # Subclasses can override to add custom validation logic
+        # ConfigValidator.validate expects a plain dict; hand it only the
+        # declared dataclass fields (not private attrs like _validator).
+        values = {
+            name: getattr(self, name) for name in self.__class__.__dataclass_fields__
+        }
+        self._validator.validate(values)
 
 
 @dataclass
@@ -244,3 +247,18 @@ class TrackIdentificationConfig(BaseConfig):
         self._validator.add_rule(
             PathRule("temp_dir", path_requirements, create_if_missing=True)
         )
+
+    def _validate(self) -> None:
+        """Run declarative rules, then cross-field checks."""
+        super()._validate()
+
+        # INVARIANT: segmentation step = segment_length - overlap_duration
+        # must be positive, or AsyncApp.split_audio's while-loop never
+        # advances (infinite loop, unbounded memory). Guarded again at the
+        # split site because config attributes are mutable after init.
+        if self.overlap_duration >= self.segment_length:
+            raise ValueError(
+                f"overlap_duration ({self.overlap_duration}) must be smaller "
+                f"than segment_length ({self.segment_length}); the segmenter "
+                f"advances by segment_length - overlap_duration each step."
+            )

--- a/src/tracklistify/core/base.py
+++ b/src/tracklistify/core/base.py
@@ -295,8 +295,8 @@ class AsyncApp:
                 f"with a non-positive step of {step}s."
             )
         if shutil.which("ffmpeg") is None:
-            self.logger.error(
-                "ffmpeg not found on PATH — segmentation will fail. "
+            raise RuntimeError(
+                "ffmpeg not found on PATH — segmentation cannot proceed. "
                 "Install it first (e.g. `apt install ffmpeg` or "
                 "`brew install ffmpeg`)."
             )

--- a/src/tracklistify/core/base.py
+++ b/src/tracklistify/core/base.py
@@ -284,6 +284,22 @@ class AsyncApp:
         segment_duration = self.config.segment_length
         overlap_duration = self.config.overlap_duration
         step = segment_duration - overlap_duration
+        # INVARIANT: step must be positive or the while-loop below never
+        # advances. Config validation enforces this at load time, but
+        # config attributes are mutable (CLI overrides mutate them), so
+        # guard again here — fail loud instead of looping forever.
+        if step <= 0:
+            raise ValueError(
+                f"segment_length ({segment_duration}) must exceed "
+                f"overlap_duration ({overlap_duration}); refusing to segment "
+                f"with a non-positive step of {step}s."
+            )
+        if shutil.which("ffmpeg") is None:
+            self.logger.error(
+                "ffmpeg not found on PATH — segmentation will fail. "
+                "Install it first (e.g. `apt install ffmpeg` or "
+                "`brew install ffmpeg`)."
+            )
 
         # Per-invocation temp dir (created in __init__) — every concurrent
         # run uses its own subdir so cleanup can't wipe peers' segments.

--- a/src/tracklistify/exporters/tracklist.py
+++ b/src/tracklistify/exporters/tracklist.py
@@ -39,7 +39,7 @@ class TracklistOutput:
         self.tracks = tracks
         self._config = get_config()
         self.output_dir = Path(self._config.output_dir)
-        self.output_dir.mkdir(exist_ok=True)
+        self.output_dir.mkdir(parents=True, exist_ok=True)
 
     def _format_filename(self, extension: str) -> str:
         """

--- a/src/tracklistify/providers/acrcloud.py
+++ b/src/tracklistify/providers/acrcloud.py
@@ -10,6 +10,8 @@ import time
 from pathlib import Path
 from typing import Dict, Optional, Union
 
+from tracklistify.core.types import AudioSegment
+
 # Third-party imports
 import aiohttp
 from aiohttp import ClientTimeout, FormData
@@ -95,7 +97,7 @@ class ACRCloudProvider(TrackIdentificationProvider):
         return {"data": data}
 
     async def identify_track(
-        self, audio_segment: Union[bytes, object], start_time: float = 0
+        self, audio_segment: Union[bytes, AudioSegment], start_time: float = 0
     ) -> Dict:
         """
         Identify a track from an audio segment or raw audio bytes.

--- a/src/tracklistify/providers/acrcloud.py
+++ b/src/tracklistify/providers/acrcloud.py
@@ -1,12 +1,14 @@
 """ACRCloud track identification provider."""
 
 # Standard library imports
+import asyncio
 import base64
 import hashlib
 import hmac
 import json
 import time
-from typing import Dict, Optional
+from pathlib import Path
+from typing import Dict, Optional, Union
 
 # Third-party imports
 import aiohttp
@@ -92,12 +94,19 @@ class ACRCloudProvider(TrackIdentificationProvider):
 
         return {"data": data}
 
-    async def identify_track(self, audio_data: bytes, start_time: float = 0) -> Dict:
+    async def identify_track(
+        self, audio_segment: Union[bytes, object], start_time: float = 0
+    ) -> Dict:
         """
-        Identify a track from audio data.
+        Identify a track from an audio segment or raw audio bytes.
+
+        The identification pipeline (``IdentificationManager``) passes an
+        ``AudioSegment`` (an object with a ``file_path`` attribute); raw
+        ``bytes`` are also accepted for direct/legacy callers.
 
         Args:
-            audio_data: Raw audio data bytes
+            audio_segment: ``AudioSegment``-like object with a ``file_path``
+                attribute, or raw audio data bytes.
             start_time: Start time in seconds for the audio segment
 
         Returns:
@@ -110,6 +119,19 @@ class ACRCloudProvider(TrackIdentificationProvider):
             ProviderError: For other provider-related errors
         """
         try:
+            if isinstance(audio_segment, (bytes, bytearray)):
+                audio_data = bytes(audio_segment)
+            else:
+                file_path = getattr(audio_segment, "file_path", None)
+                if not file_path:
+                    raise ProviderError(
+                        "ACRCloud identify_track needs raw bytes or an "
+                        "AudioSegment with a file_path attribute; got "
+                        f"{type(audio_segment).__name__}"
+                    )
+                # File reads block; do them off the event loop.
+                audio_data = await asyncio.to_thread(Path(file_path).read_bytes)
+
             session = await self._get_session()
             request_data = self._prepare_request_data(audio_data, start_time)
 
@@ -186,7 +208,12 @@ class ACRCloudProvider(TrackIdentificationProvider):
                     "metadata": {"music": music_list},
                 }
 
-        except (AuthenticationError, RateLimitError, IdentificationError) as err:
+        except (
+            AuthenticationError,
+            RateLimitError,
+            IdentificationError,
+            ProviderError,
+        ) as err:
             raise err from None
         except Exception as err:
             raise ProviderError(f"ACRCloud provider error: {str(err)}") from err

--- a/src/tracklistify/providers/factory.py
+++ b/src/tracklistify/providers/factory.py
@@ -1,12 +1,20 @@
 """Provider factory for creating track identification providers."""
 
 # Standard library imports
+import os
 import threading
 
 # Local imports
+from tracklistify.core.exceptions import ConfigError
 
 _provider_factory = None
 _provider_lock = threading.Lock()
+
+# Provider names this factory knows how to build. Keep in sync with the
+# branches in ProviderFactory.get_identification_provider — the invariant
+# test in tests/test_handoff_invariants.py checks each name constructs
+# (or fails with a clear ConfigError, never a TypeError).
+KNOWN_PROVIDERS = ("shazam", "acrcloud")
 
 
 def create_provider_factory() -> "ProviderFactory":
@@ -65,9 +73,33 @@ class ProviderFactory:
             elif provider_name == "acrcloud":
                 from tracklistify.providers.acrcloud import ACRCloudProvider
 
-                provider = ACRCloudProvider()
+                # Credentials are read from the environment (documented in
+                # .env.example), NOT from the config dataclass — keeping
+                # secrets off the dataclass avoids leaking them via repr()
+                # or error messages.
+                access_key = os.getenv("TRACKLISTIFY_ACR_ACCESS_KEY")
+                access_secret = os.getenv("TRACKLISTIFY_ACR_ACCESS_SECRET")
+                if not access_key or not access_secret:
+                    raise ConfigError(
+                        "ACRCloud provider requires TRACKLISTIFY_ACR_ACCESS_KEY "
+                        "and TRACKLISTIFY_ACR_ACCESS_SECRET in the environment "
+                        "or .env file. Get credentials at "
+                        "https://console.acrcloud.com/ or use "
+                        "`--provider shazam` (no credentials needed)."
+                    )
+                host = os.getenv(
+                    "TRACKLISTIFY_ACR_HOST", "identify-eu-west-1.acrcloud.com"
+                )
+                provider = ACRCloudProvider(
+                    access_key=access_key,
+                    access_secret=access_secret,
+                    host=host,
+                )
             else:
-                raise ValueError(f"Unknown provider: {provider_name}")
+                raise ValueError(
+                    f"Unknown provider: {provider_name!r}. "
+                    f"Known providers: {', '.join(KNOWN_PROVIDERS)}"
+                )
             self.providers[provider_name] = provider
             return provider
 

--- a/src/tracklistify/providers/spotify.py
+++ b/src/tracklistify/providers/spotify.py
@@ -124,8 +124,12 @@ class SpotifyProvider(MetadataProvider):
         ) as response:
             if response.status == 429:
                 retry_after = int(response.headers.get("Retry-After", 60))
+                # Pass retry_after as a structured attribute, not just in the
+                # message — callers honor RateLimitError.retry_after for backoff.
                 raise RateLimitError(
-                    f"Spotify rate limit exceeded. Retry after {retry_after}s"
+                    f"Spotify rate limit exceeded. Retry after {retry_after}s",
+                    provider="spotify",
+                    retry_after=retry_after,
                 )
             if response.status == 401:
                 self._access_token = None

--- a/src/tracklistify/utils/identification.py
+++ b/src/tracklistify/utils/identification.py
@@ -4,6 +4,7 @@ Track identification helper functions and utilities.
 
 # Standard library imports
 import asyncio
+import contextlib
 import sys
 import time
 from typing import List, Optional
@@ -192,76 +193,113 @@ class IdentificationManager:
         self.provider_factory = provider_factory or create_provider_factory()
         self.track_matcher = TrackMatcher()
 
+    def _provider_chain(self) -> List[str]:
+        """Resolve the ordered provider chain: primary, then fallbacks.
+
+        Fallback providers are only appended when ``fallback_enabled`` is
+        set (config default, or ``--no-fallback`` CLI override). Duplicates
+        of the primary are dropped so a segment is never retried on the
+        same provider.
+        """
+        chain = [self.config.primary_provider]
+        if getattr(self.config, "fallback_enabled", False):
+            for name in getattr(self.config, "fallback_providers", None) or []:
+                if name not in chain:
+                    chain.append(name)
+        return chain
+
+    def _track_from_info(self, track_info, segment) -> Optional[Track]:
+        """Build a ``Track`` from a provider response dict, or None.
+
+        Providers return ``{"metadata": {"music": [{title, artists,
+        score}]}}``; anything that doesn't parse into a valid Track (empty
+        music list, blank title/artist, out-of-range score) yields None so
+        the caller can fall back to the next provider.
+        """
+        if track_info is None:
+            return None
+        music_list = track_info.get("metadata", {}).get("music", [])
+        if not music_list or not music_list[0]:
+            logger.debug("No track metadata in provider response")
+            return None
+        metadata = music_list[0]
+
+        time_in_mix = format_seconds_to_hhmmss(int(segment.start_time))
+        artists_list = metadata.get("artists", [])
+        artist_name = (
+            artists_list[0].get("name", "Unknown Artist")
+            if artists_list
+            else "Unknown Artist"
+        )
+        try:
+            return Track(
+                song_name=metadata.get("title", "Unknown Title"),
+                artist=artist_name,
+                time_in_mix=time_in_mix,
+                confidence=float(metadata.get("score", 100.0)),
+            )
+        except (ValueError, TypeError) as e:
+            logger.error(f"Failed to create track from provider response: {e}")
+            return None
+
     async def identify_tracks(self, audio_segments):
-        provider_name = self.config.primary_provider
-        provider = self.provider_factory.get_identification_provider(provider_name)
+        provider_names = self._provider_chain()
+
+        # Instantiate providers up front. A broken PRIMARY is fatal (raise,
+        # with the factory's actionable message); a broken FALLBACK is
+        # skipped with a warning so it can't take down the whole run.
+        chain = []
+        for name in provider_names:
+            try:
+                provider = self.provider_factory.get_identification_provider(name)
+                chain.append((name, provider))
+            except Exception as e:
+                if name == self.config.primary_provider:
+                    raise
+                logger.warning(f"Skipping unusable fallback provider {name!r}: {e}")
+
         identified_tracks = []
         limiter = get_global_rate_limiter()
 
-        # ``async with provider`` ensures aiohttp sessions / shazamio resources
-        # are closed even if an exception escapes the loop.
-        async with provider:
+        # Enter every provider's async context so aiohttp/shazamio
+        # resources are closed even if an exception escapes the loop.
+        async with contextlib.AsyncExitStack() as stack:
+            for _, provider in chain:
+                await stack.enter_async_context(provider)
+
             for segment in audio_segments:
-                acquired = False
-                try:
-                    acquired = await limiter.acquire(provider_name)
-                    if not acquired:
-                        logger.warning(
-                            f"Rate limiter rejected request for {provider_name}; "
-                            "skipping segment"
-                        )
-                        continue
-
-                    track_info = await provider.identify_track(segment)
-                    if track_info is None:
-                        logger.debug("Provider returned None for track identification")
-                        continue
-
-                    # Extract track metadata with safe array access
-                    music_list = track_info.get("metadata", {}).get("music", [])
-                    if not music_list:
-                        logger.error("No track metadata found in provider response")
-                        continue
-                    metadata = music_list[0] if music_list else {}
-                    if not metadata:
-                        logger.error("Empty track metadata in provider response")
-                        continue
-
-                    # Format time in mix with proper zero-padding
-                    time_in_mix = format_seconds_to_hhmmss(int(segment.start_time))
-
-                    # Safely extract artist name with default
-                    artists_list = metadata.get("artists", [])
-                    artist_name = (
-                        artists_list[0].get("name", "Unknown Artist")
-                        if artists_list
-                        else "Unknown Artist"
-                    )
-
+                track = None
+                for provider_name, provider in chain:
+                    acquired = False
                     try:
-                        track = Track(
-                            song_name=metadata.get("title", "Unknown Title"),
-                            artist=artist_name,
-                            time_in_mix=time_in_mix,
-                            confidence=float(metadata.get("score", 100.0)),
-                        )
-                        self.track_matcher.add_track(track)
-                        identified_tracks.append(track)
-                    except ValueError as e:
-                        logger.error(f"Failed to create track: {e}")
-                        continue
+                        acquired = await limiter.acquire(provider_name)
+                        if not acquired:
+                            logger.warning(
+                                f"Rate limiter rejected request for "
+                                f"{provider_name}; trying next provider"
+                            )
+                            continue
+                        track_info = await provider.identify_track(segment)
+                        limiter.record_result(provider_name, success=True)
+                        track = self._track_from_info(track_info, segment)
+                        if track is not None:
+                            break
+                    except asyncio.CancelledError:
+                        raise
                     except Exception as e:
-                        logger.error(f"Unexpected error creating track: {e}")
+                        limiter.record_result(provider_name, success=False)
+                        logger.error(
+                            f"{provider_name} identification failed for "
+                            f"segment at {segment.start_time}s: {e}"
+                        )
                         continue
+                    finally:
+                        if acquired:
+                            limiter.release(provider_name)
 
-                except asyncio.CancelledError:
-                    raise
-                except Exception as e:
-                    logger.error(f"Identification failed for segment: {e}")
-                    continue
-                finally:
-                    if acquired:
-                        limiter.release(provider_name)
+                if track is not None:
+                    self.track_matcher.add_track(track)
+                    identified_tracks.append(track)
 
         # Get unique tracks sorted by time in mix
         unique_tracks = self.track_matcher.get_unique_tracks()
@@ -277,21 +315,3 @@ class IdentificationManager:
         """Cleanup resources."""
         if self.provider_factory:
             await self.provider_factory.close_all()
-
-
-async def identify_tracks(audio_path: str) -> Optional[List[Track]]:
-    """
-    Identify tracks in an audio file.
-
-    Args:
-        audio_path: Path to audio file
-
-    Returns:
-        List[Track]: List of identified tracks, or None if identification failed
-    """
-    try:
-        manager = IdentificationManager()
-        return await manager.identify_tracks(audio_path)
-    except Exception as e:
-        logger.error(f"Track identification failed: {e}")
-        return None

--- a/src/tracklistify/utils/rate_limiter.py
+++ b/src/tracklistify/utils/rate_limiter.py
@@ -249,6 +249,17 @@ class RateLimiter:
             limits.semaphore.release()
             raise
 
+    def record_result(self, provider: Any, success: bool) -> None:
+        """Record the outcome of a provider request for the circuit breaker.
+
+        Callers MUST invoke this after each provider request (success=True
+        on a normal response, False on an exception) or the circuit
+        breaker never learns about failures and never opens. The
+        identification loop in ``utils/identification.py`` is the primary
+        caller.
+        """
+        self._update_circuit_breaker(provider, success)
+
     def release(self, provider: Any):
         """Release a concurrent request slot."""
         if provider in self._provider_limits:

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -120,6 +120,6 @@ class TestExceptionLogging:
             content = f.read()
 
         # Should have logging for cooldown failures
-        assert (
-            "logger.debug" in content and "cooldown" in content.lower()
-        ), "Shazam should log cooldown configuration failures"
+        assert "logger.debug" in content and "cooldown" in content.lower(), (
+            "Shazam should log cooldown configuration failures"
+        )

--- a/tests/test_handoff_invariants.py
+++ b/tests/test_handoff_invariants.py
@@ -1,0 +1,431 @@
+"""Invariant tests from the 2026-07 handoff audit.
+
+Each test class locks one named invariant that the production pipeline
+depends on. If one of these fails, something load-bearing broke — read
+docs/ARCHITECTURE.md before "fixing" the test.
+
+INVARIANTS COVERED
+  I1  Config validation rules are enforced at construction time.
+  I2  Segmentation step (segment_length - overlap_duration) is positive,
+      both at config load and again inside split_audio (config attrs are
+      mutable after load).
+  I3  Every provider name in providers.factory.KNOWN_PROVIDERS is
+      constructible through the factory, or fails with an actionable
+      ConfigError — never a TypeError.
+  I4  ACRCloudProvider.identify_track accepts the pipeline's AudioSegment
+      (an object with file_path), not just raw bytes.
+  I5  Provider fallback: when fallback_enabled and the primary yields
+      nothing, fallback providers are tried in order; when disabled, they
+      are not.
+  I6  Provider failures feed the rate limiter's circuit breaker via
+      RateLimiter.record_result.
+  I7  Cache TTL expiry works (a set() without explicit ttl inherits the
+      cache-level TTL instead of storing None, which disabled expiry).
+  I8  Cache index is persisted on every set/delete, so a second process
+      (fresh CacheIndex) sees entries written by the first.
+"""
+
+import time
+from unittest.mock import AsyncMock, patch
+
+import pytest
+
+from tracklistify.core.exceptions import ConfigError
+from tracklistify.core.types import AudioSegment
+
+
+# ---------------------------------------------------------------------------
+# I1 / I2 — config validation
+# ---------------------------------------------------------------------------
+
+
+class TestConfigValidationEnforced:
+    def _fresh_config(self, monkeypatch, tmp_path, **env):
+        for key in ("SEGMENT_LENGTH", "OVERLAP_DURATION", "MIN_CONFIDENCE"):
+            monkeypatch.delenv(f"TRACKLISTIFY_{key}", raising=False)
+        monkeypatch.setenv("TRACKLISTIFY_OUTPUT_DIR", str(tmp_path / "out"))
+        monkeypatch.setenv("TRACKLISTIFY_CACHE_DIR", str(tmp_path / "cache"))
+        monkeypatch.setenv("TRACKLISTIFY_TEMP_DIR", str(tmp_path / "temp"))
+        monkeypatch.setenv("TRACKLISTIFY_LOG_DIR", str(tmp_path / "log"))
+        for key, value in env.items():
+            monkeypatch.setenv(f"TRACKLISTIFY_{key}", value)
+        from tracklistify.config import get_config
+
+        return get_config(force_refresh=True)
+
+    def test_out_of_range_segment_length_rejected(self, monkeypatch, tmp_path):
+        """I1: range rules registered in _setup_validation actually run."""
+        with pytest.raises(Exception, match="segment_length"):
+            self._fresh_config(monkeypatch, tmp_path, SEGMENT_LENGTH="5000")
+
+    def test_out_of_range_min_confidence_rejected(self, monkeypatch, tmp_path):
+        with pytest.raises(Exception, match="min_confidence"):
+            self._fresh_config(monkeypatch, tmp_path, MIN_CONFIDENCE="7.5")
+
+    def test_overlap_must_be_smaller_than_segment(self, monkeypatch, tmp_path):
+        """I2 (config half): step <= 0 would hang split_audio forever."""
+        with pytest.raises(ValueError, match="overlap_duration"):
+            self._fresh_config(
+                monkeypatch, tmp_path, SEGMENT_LENGTH="20", OVERLAP_DURATION="20"
+            )
+
+    def test_valid_config_still_loads(self, monkeypatch, tmp_path):
+        cfg = self._fresh_config(
+            monkeypatch, tmp_path, SEGMENT_LENGTH="120", OVERLAP_DURATION="10"
+        )
+        assert cfg.segment_length == 120
+
+
+class TestSplitAudioStepGuard:
+    def test_split_audio_refuses_non_positive_step(self, monkeypatch, tmp_path):
+        """I2 (runtime half): guard fires even when config is mutated
+        after construction, which validation can't see."""
+        monkeypatch.setenv("TRACKLISTIFY_TEMP_DIR", str(tmp_path))
+        from tracklistify.config import get_config
+        from tracklistify.core.base import AsyncApp
+
+        config = get_config(force_refresh=True)
+        app = AsyncApp(config)
+        app.config.segment_length = 10
+        app.config.overlap_duration = 10  # step == 0
+        with pytest.raises(ValueError, match="non-positive step"):
+            app.split_audio(str(tmp_path / "whatever.mp3"), duration_hint=60.0)
+
+
+# ---------------------------------------------------------------------------
+# I3 / I4 — provider construction and pipeline compatibility
+# ---------------------------------------------------------------------------
+
+
+class TestProviderFactoryInvariants:
+    def test_all_known_providers_construct_or_config_error(self, monkeypatch):
+        """I3: `-p <name>` must never die with a bare TypeError."""
+        monkeypatch.delenv("TRACKLISTIFY_ACR_ACCESS_KEY", raising=False)
+        monkeypatch.delenv("TRACKLISTIFY_ACR_ACCESS_SECRET", raising=False)
+        from tracklistify.providers.factory import KNOWN_PROVIDERS, ProviderFactory
+
+        for name in KNOWN_PROVIDERS:
+            factory = ProviderFactory()
+            try:
+                provider = factory.get_identification_provider(name)
+                assert provider is not None
+            except ConfigError as e:
+                # Acceptable: missing credentials, with an actionable message.
+                assert "TRACKLISTIFY_" in str(e), (
+                    f"ConfigError for {name!r} must name the env vars to set"
+                )
+
+    def test_acrcloud_constructs_with_credentials(self, monkeypatch):
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_KEY", "test-key")
+        monkeypatch.setenv("TRACKLISTIFY_ACR_ACCESS_SECRET", "test-secret")
+        from tracklistify.providers.factory import ProviderFactory
+
+        provider = ProviderFactory().get_identification_provider("acrcloud")
+        assert provider.access_key == "test-key"
+
+    def test_unknown_provider_names_known_ones(self):
+        from tracklistify.providers.factory import ProviderFactory
+
+        with pytest.raises(ValueError, match="shazam"):
+            ProviderFactory().get_identification_provider("nope")
+
+    @pytest.mark.asyncio
+    async def test_acrcloud_identify_accepts_audio_segment(self, tmp_path):
+        """I4: the pipeline passes AudioSegment, not bytes."""
+        from tracklistify.providers.acrcloud import ACRCloudProvider
+
+        audio_file = tmp_path / "seg.mp3"
+        audio_file.write_bytes(b"\xff\xfb\x90\x00" + b"\x00" * 100)
+        segment = AudioSegment(file_path=str(audio_file), start_time=0, duration=60)
+
+        provider = ACRCloudProvider(access_key="k", access_secret="s")
+        captured = {}
+
+        class FakeResponse:
+            status = 200
+
+            async def text(self):
+                return (
+                    '{"status": {"code": 0, "msg": "ok"}, "metadata": {"music": '
+                    '[{"title": "Song", "artists": [{"name": "Artist"}], '
+                    '"score": 95}]}}'
+                )
+
+            async def __aenter__(self):
+                return self
+
+            async def __aexit__(self, *args):
+                return False
+
+        class FakeSession:
+            def post(self, url, data=None):
+                captured["posted"] = True
+                return FakeResponse()
+
+        provider._get_session = AsyncMock(return_value=FakeSession())
+        result = await provider.identify_track(segment)
+        assert captured.get("posted"), "identify_track never reached the API call"
+        assert result["metadata"]["music"][0]["title"] == "Song"
+
+
+# ---------------------------------------------------------------------------
+# I5 / I6 — fallback chain and circuit-breaker wiring
+# ---------------------------------------------------------------------------
+
+
+class _StubProvider:
+    """Minimal TrackIdentificationProvider stand-in."""
+
+    def __init__(self, response=None, error=None):
+        self.response = response
+        self.error = error
+        self.calls = 0
+
+    async def identify_track(self, segment):
+        self.calls += 1
+        if self.error is not None:
+            raise self.error
+        return self.response
+
+    async def close(self):
+        pass
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *args):
+        await self.close()
+
+
+class _StubFactory:
+    def __init__(self, providers):
+        self._providers = providers
+
+    def get_identification_provider(self, name):
+        return self._providers[name]
+
+    async def close_all(self):
+        pass
+
+
+def _match(title="Fallback Song"):
+    return {
+        "metadata": {
+            "music": [{"title": title, "artists": [{"name": "A"}], "score": 90}]
+        }
+    }
+
+
+class TestFallbackChain:
+    def _manager(self, monkeypatch, providers, fallback_enabled):
+        from tracklistify.config import get_config
+        from tracklistify.utils.identification import IdentificationManager
+        from tracklistify.utils import rate_limiter as rl
+
+        monkeypatch.setattr(
+            rl, "get_global_rate_limiter", lambda force_refresh=False: rl.RateLimiter()
+        )
+        # identification.py imported the symbol directly; patch there too.
+        import tracklistify.utils.identification as ident_mod
+
+        monkeypatch.setattr(
+            ident_mod, "get_global_rate_limiter", lambda: rl.RateLimiter()
+        )
+
+        config = get_config(force_refresh=True)
+        config.primary_provider = "primary"
+        config.fallback_enabled = fallback_enabled
+        config.fallback_providers = ["backup"]
+        return IdentificationManager(
+            config=config, provider_factory=_StubFactory(providers)
+        )
+
+    @pytest.mark.asyncio
+    async def test_fallback_used_when_primary_returns_nothing(self, monkeypatch):
+        """I5: primary miss -> fallback provider is consulted."""
+        primary = _StubProvider(response=None)
+        backup = _StubProvider(response=_match())
+        manager = self._manager(
+            monkeypatch, {"primary": primary, "backup": backup}, fallback_enabled=True
+        )
+        segments = [AudioSegment(file_path="x", start_time=0, duration=60)]
+        tracks = await manager.identify_tracks(segments)
+        assert backup.calls == 1
+        assert len(tracks) == 1 and tracks[0].song_name == "Fallback Song"
+
+    @pytest.mark.asyncio
+    async def test_fallback_not_used_when_disabled(self, monkeypatch):
+        primary = _StubProvider(response=None)
+        backup = _StubProvider(response=_match())
+        manager = self._manager(
+            monkeypatch, {"primary": primary, "backup": backup}, fallback_enabled=False
+        )
+        segments = [AudioSegment(file_path="x", start_time=0, duration=60)]
+        tracks = await manager.identify_tracks(segments)
+        assert backup.calls == 0
+        assert tracks == []
+
+    @pytest.mark.asyncio
+    async def test_fallback_skipped_when_primary_matches(self, monkeypatch):
+        primary = _StubProvider(response=_match("Primary Song"))
+        backup = _StubProvider(response=_match())
+        manager = self._manager(
+            monkeypatch, {"primary": primary, "backup": backup}, fallback_enabled=True
+        )
+        segments = [AudioSegment(file_path="x", start_time=0, duration=60)]
+        tracks = await manager.identify_tracks(segments)
+        assert backup.calls == 0
+        assert tracks[0].song_name == "Primary Song"
+
+    @pytest.mark.asyncio
+    async def test_provider_exception_falls_through_to_backup(self, monkeypatch):
+        primary = _StubProvider(error=RuntimeError("provider down"))
+        backup = _StubProvider(response=_match())
+        manager = self._manager(
+            monkeypatch, {"primary": primary, "backup": backup}, fallback_enabled=True
+        )
+        segments = [AudioSegment(file_path="x", start_time=0, duration=60)]
+        tracks = await manager.identify_tracks(segments)
+        assert len(tracks) == 1
+
+
+class TestCircuitBreakerWiring:
+    def test_record_result_trips_breaker(self):
+        """I6: repeated failures open the circuit via the public API."""
+        from tracklistify.utils.rate_limiter import CircuitState, RateLimiter
+
+        limiter = RateLimiter()
+        limiter.register_provider("prov", 10, 2)
+        threshold = getattr(limiter._config, "circuit_breaker_threshold", 5)
+        for _ in range(threshold):
+            limiter.record_result("prov", success=False)
+        assert limiter._provider_limits["prov"].circuit_state == CircuitState.OPEN, (
+            "circuit breaker did not open after threshold failures"
+        )
+
+    @pytest.mark.asyncio
+    async def test_identification_reports_failures_to_breaker(self, monkeypatch):
+        """The identify loop must call record_result on provider errors."""
+        from tracklistify.config import get_config
+        from tracklistify.utils.identification import IdentificationManager
+        from tracklistify.utils.rate_limiter import RateLimiter
+        import tracklistify.utils.identification as ident_mod
+
+        limiter = RateLimiter()
+        recorded = []
+        monkeypatch.setattr(
+            limiter,
+            "record_result",
+            lambda provider, success: recorded.append((provider, success)),
+        )
+        monkeypatch.setattr(ident_mod, "get_global_rate_limiter", lambda: limiter)
+
+        config = get_config(force_refresh=True)
+        config.primary_provider = "primary"
+        config.fallback_enabled = False
+        failing = _StubProvider(error=RuntimeError("boom"))
+        manager = IdentificationManager(
+            config=config, provider_factory=_StubFactory({"primary": failing})
+        )
+        await manager.identify_tracks(
+            [AudioSegment(file_path="x", start_time=0, duration=60)]
+        )
+        assert ("primary", False) in recorded
+
+
+# ---------------------------------------------------------------------------
+# I7 / I8 — cache subsystem safety (unwired today, but must be safe to wire)
+# ---------------------------------------------------------------------------
+
+
+class TestCacheTTL:
+    @pytest.mark.asyncio
+    async def test_entries_expire_after_ttl(self, tmp_path, monkeypatch):
+        """I7: set() without explicit ttl inherits the cache TTL."""
+        monkeypatch.setenv("TRACKLISTIFY_CACHE_DIR", str(tmp_path))
+        from tracklistify.cache.factory import create_cache
+
+        cache = create_cache(cache_dir=tmp_path, ttl=10)
+        await cache.set("key", {"data": 1})
+        assert await cache.get("key") == {"data": 1}
+
+        # Age the entry past its TTL by rewriting its created timestamp.
+        entry = await cache._storage.get("key")
+        assert entry["metadata"]["ttl"] == 10, (
+            "set() must stamp the cache-level TTL, not None (None disables expiry)"
+        )
+        entry["metadata"]["created"] = time.time() - 11
+        entry["metadata"]["last_accessed"] = time.time() - 11
+        await cache._storage.set("key", entry)
+
+        assert await cache.get("key") is None, "entry older than ttl must expire"
+
+
+class TestCacheIndexPersistence:
+    @pytest.mark.asyncio
+    async def test_second_storage_instance_sees_entries(self, tmp_path, monkeypatch):
+        """I8: a fresh process (new index object) must see prior writes."""
+        monkeypatch.setenv("TRACKLISTIFY_CACHE_DIR", str(tmp_path))
+        from tracklistify.cache.storage import JSONStorage
+
+        storage_a = JSONStorage(tmp_path)
+        entry = {
+            "key": "k1",
+            "value": {"x": 1},
+            "metadata": {
+                "created": time.time(),
+                "last_accessed": time.time(),
+                "ttl": 3600,
+                "compression": False,
+                "size": 8,
+            },
+        }
+        await storage_a.set("k1", entry)
+
+        # Simulate a new process: brand-new storage + index over same dir.
+        storage_b = JSONStorage(tmp_path)
+        loaded = await storage_b.get("k1")
+        assert loaded is not None and loaded["value"] == {"x": 1}, (
+            "index was not persisted on set(); entries written by one "
+            "process are invisible (and later deleted as orphans) in the next"
+        )
+
+
+# ---------------------------------------------------------------------------
+# CLI fail-fast
+# ---------------------------------------------------------------------------
+
+
+class TestCliFfmpegCheck:
+    def test_cli_exits_early_without_ffmpeg(self, monkeypatch):
+        from tracklistify import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda name: None)
+        monkeypatch.setattr(
+            cli_mod.sys, "argv", ["tracklistify", "http://youtube.com/watch?v=x"]
+        )
+        with pytest.raises(SystemExit) as exc_info:
+            cli_mod.cli()
+        assert exc_info.value.code == 1
+
+    def test_cli_proceeds_with_ffmpeg(self, monkeypatch):
+        """With ffmpeg present, cli() must get past the check (we stop it
+        at asyncio.run to avoid a real run)."""
+        from tracklistify import cli as cli_mod
+
+        monkeypatch.setattr(cli_mod.shutil, "which", lambda name: "/usr/bin/ffmpeg")
+        monkeypatch.setattr(
+            cli_mod.sys, "argv", ["tracklistify", "http://youtube.com/watch?v=x"]
+        )
+
+        def fake_asyncio_run(coro):
+            coro.close()  # avoid "coroutine never awaited" warnings
+            return 0
+
+        with patch.object(
+            cli_mod.asyncio, "run", side_effect=fake_asyncio_run
+        ) as fake_run:
+            with pytest.raises(SystemExit) as exc_info:
+                cli_mod.cli()
+        assert fake_run.called
+        assert exc_info.value.code == 0

--- a/tests/test_logger.py
+++ b/tests/test_logger.py
@@ -64,9 +64,9 @@ class TestLoggerConfiguration:
         set_logger(log_level="DEBUG")
         handler_count_2 = len(logger.handlers)
 
-        assert (
-            handler_count_1 == handler_count_2
-        ), f"Handlers duplicated: {handler_count_1} vs {handler_count_2}"
+        assert handler_count_1 == handler_count_2, (
+            f"Handlers duplicated: {handler_count_1} vs {handler_count_2}"
+        )
 
     def test_multiple_calls_dont_duplicate_handlers(self):
         """Test that multiple set_logger calls don't duplicate handlers."""
@@ -77,9 +77,9 @@ class TestLoggerConfiguration:
         logger = logging.getLogger()
 
         # Should only have 1 console handler
-        assert (
-            len(logger.handlers) == 1
-        ), f"Expected 1 handler, got {len(logger.handlers)}"
+        assert len(logger.handlers) == 1, (
+            f"Expected 1 handler, got {len(logger.handlers)}"
+        )
 
     def test_file_handler_added_when_specified(self, tmp_path):
         """Test that file handler is added when log_file specified."""
@@ -141,9 +141,9 @@ class TestLoggerConfiguration:
         set_logger(log_level="INFO", log_file=log_file)
 
         # The pre-reconfig handler's underlying stream must be closed.
-        assert (
-            original.stream is None or original.stream.closed
-        ), "previous file handler should be closed on reconfigure"
+        assert original.stream is None or original.stream.closed, (
+            "previous file handler should be closed on reconfigure"
+        )
 
     def test_log_level_changes_applied(self):
         """Test that log level changes are applied correctly."""


### PR DESCRIPTION
# Handoff audit: fixes + self-enforcing guardrails

Full principal-architect audit of the codebase (recon → deep audit → remediation → infrastructure). Every fix is locked by an invariant test in `tests/test_handoff_invariants.py` (I1–I8), and the judgment behind them is encoded in three new docs so it survives the handoff.

## Correctness fixes (production path)

| Bug | Impact | Fix |
|---|---|---|
| **Config validation never ran** — `BaseConfig._validate()` had an empty body; the ~13 type/range/path rules registered in `_setup_validation` were dead code | Any garbage env value accepted silently | `_validate()` now feeds dataclass fields to `ConfigValidator`; added cross-field rule `overlap_duration < segment_length` (I1) |
| **Infinite loop in `split_audio`** when `overlap_duration >= segment_length` (step ≤ 0 → while-loop never advances) | Hang + unbounded memory | Runtime guard raises with actionable message; config is mutable post-load so the config-time check alone wasn't enough (I2) |
| **ACRCloud provider unusable since inception** — factory called `ACRCloudProvider()` with no credentials (instant `TypeError`), and `identify_track` took raw `bytes` while the pipeline passes `AudioSegment` | `-p acrcloud` crashed unconditionally | Factory reads `TRACKLISTIFY_ACR_ACCESS_KEY/_SECRET/_HOST` from env (secrets deliberately kept off the config dataclass), raises `ConfigError` naming the exact vars when missing; `identify_track` accepts `AudioSegment` or bytes (I3, I4) |
| **Provider fallback was a no-op** — `fallback_enabled`, `fallback_providers`, and `--no-fallback` were read by nothing | Documented feature didn't exist | `IdentificationManager` walks a primary→fallback provider chain per segment, with per-provider rate limiting (I5) |
| **Circuit breaker never learned** — `_update_circuit_breaker` had zero production callers | Breaker could never open | New public `RateLimiter.record_result()`, called on every provider outcome (I6) |
| **Cache TTL disabled** — `set()` stored `ttl: None`, which shadowed the strategy default in `metadata.get("ttl", default_ttl)`, so `is_valid` always returned True | Entries never expired | `set()` stamps the cache-level TTL (I7) |
| **Cache index only persisted from `cleanup()`/`clear()`** | Entries written by one process invisible to the next, then deleted as "orphans" by the next cleanup — silent data loss | Index persisted on every `set`/`delete`; index save now fsyncs before rename (I8) |

Smaller: CLI fail-fast when ffmpeg missing (was a cryptic per-segment error); exporter `mkdir(parents=True)`; Spotify 429 carries structured `retry_after`; `cz bump` repaired (`version_provider` was still `"poetry"` post-uv-migration); `scripts/generate_config_docs.py` called a method that never existed; removed dead module-level `identify_tracks()` that iterated a string as segments.

## Infrastructure (the actual deliverable)

- **CI** (`.github/workflows/ci.yml`) — the repo had **no CI at all**. Now: ruff lint + format check, `.env.example` drift check (`generate_env_example.py --check`), pytest on 3.11/3.12/3.13 with ffmpeg installed.
- **`tests/test_handoff_invariants.py`** — 19 tests locking the 8 named invariants above; header explains each.
- **`docs/ARCHITECTURE.md`** — load-bearing inventory (ranked by blast radius), implicit contracts, landmines (e.g. `min_confidence` is 0–1 while `Track.confidence` is 0–100 and the knob is deliberately unwired; the cache subsystem is still not wired into the pipeline), and touch-X-update-Y couplings.
- **`docs/PLAYBOOKS.md`** — literal step-by-step procedures (add a provider / config option / output format; touch split_audio / rate limiter / config loading; 3am "no tracks identified" triage), each ending with exact verification commands and the real trap that motivated it.
- **`docs/BACKLOG.md`** — residual risk register: P1 wire the cache into identification (now safe; plan included), P2 `min_confidence` decision, P2 Spotify enrichment wiring vs. the broken client-credentials `/me/*` playlist path, P3 dead `downloaders/spotify.py`, dev_cli cleanup, security polish. Plus a "fixed, do not re-fix" table.
- **CLAUDE.md** — corrected a gotcha that lied (per-module logger overrides don't exist), added the new invariants and doc pointers.

## Verification

- `uv run python -m pytest -q` → **388 passed** (369 pre-existing + 19 new), 2 environment skips
- `uv run ruff check` / `ruff format --check` on `src/ tests/ scripts/` → clean
- `uv run python scripts/generate_env_example.py --check` → in sync
- End-to-end with real ffmpeg: generated a 180 s audio file, ran `AsyncApp.split_audio` → 4 segments at the correct 50 s stride, sorted, non-empty; step guard fires with the actionable message
- Empirically confirmed each bug before fixing (e.g. `ACRCloudProvider` TypeError via factory, out-of-range `TRACKLISTIFY_SEGMENT_LENGTH=5000` accepted pre-fix, rejected post-fix)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01LRC2BkXVyNBfa2a6w844uU

---
_Generated by [Claude Code](https://claude.ai/code/session_01LRC2BkXVyNBfa2a6w844uU)_