### PR TITLE
fix(ci): set least-privilege permissions on CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,13 @@ on:
     branches: [main]
   pull_request:
 
+# Least-privilege: every job only reads the repo. No job publishes releases,
+# pushes commits, or deploys — so the GITHUB_TOKEN needs nothing beyond
+# contents: read. Without this block the token inherits the repo default
+# (broader write scopes), which CodeQL flags as actions/missing-workflow-permissions.
+permissions:
+  contents: read
+
 jobs:
   lint:
     runs-on: ubuntu-latest


### PR DESCRIPTION
Adds an explicit permissions: contents: read block to ci.yml. Every job only checks out code and runs tests — none publish, push, or deploy — so the GITHUB_TOKEN needs nothing beyond read access. Without this block the token inherits the repo's broader default scopes, which CodeQL flags as actions/missing-workflow-permissions (3 open medium alerts).