### PR TITLE
fix: Shazam typed errors, Spotify async metadata, perf salvages

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,7 +9,7 @@ repos:
     -   id: requirements-txt-fixer
 
 -   repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.8.0
+    rev: v0.16.0
     hooks:
     -   id: ruff
         types_or: [ python, pyi ]

--- a/src/tracklistify/cache/invalidation.py
+++ b/src/tracklistify/cache/invalidation.py
@@ -284,8 +284,14 @@ class SizeStrategy(InvalidationStrategy[T]):
             return False
 
     async def update_metadata(self, entry: CacheEntry[T]) -> CacheEntry[T]:
-        """Update entry metadata."""
+        """Update entry metadata.
+
+        The size is computed once at set-time; reuse it when present to
+        avoid re-serializing the value via json.dumps on every access.
+        """
         try:
+            if "size" in entry["metadata"]:
+                return entry
             entry = copy.deepcopy(entry)
             entry["metadata"]["size"] = len(json.dumps(entry["value"]))
             return entry

--- a/src/tracklistify/core/track.py
+++ b/src/tracklistify/core/track.py
@@ -210,35 +210,22 @@ class TrackMatcher:
         )
 
     def get_unique_tracks(self) -> List[Track]:
-        """Get list of unique tracks, sorted by time in mix."""
-        # Sort tracks by time in mix
+        """Get list of unique tracks, sorted by time in mix.
+
+        Single pass into a dict keyed by ``artist|song`` (O(n)), replacing
+        the previous O(n^2) linear-scan + ``list.remove`` for each duplicate.
+        Tie-breaking is preserved: among equal keys, the highest-confidence
+        track wins (earliest-wins on ties since the input is pre-sorted by
+        time and dict insertion order is stable in Python 3.7+).
+        """
         sorted_tracks = sorted(self.tracks, key=lambda t: t.time_to_seconds())
-
-        # Filter out duplicates keeping only the highest confidence version
-        unique_tracks = []
-        seen_tracks = set()
-
+        best_by_key: Dict[str, Track] = {}
         for track in sorted_tracks:
-            # Create a unique key for the track
             track_key = f"{track.artist.lower()}|{track.song_name.lower()}"
-
-            # If seen this track before, or has higher confidence
-            if track_key not in seen_tracks:
-                seen_tracks.add(track_key)
-                unique_tracks.append(track)
-            else:
-                # Find existing track and keep the one with higher confidence
-                existing_track = next(
-                    t
-                    for t in unique_tracks
-                    if f"{t.artist.lower()}|{t.song_name.lower()}" == track_key
-                )
-                if track.confidence > existing_track.confidence:
-                    unique_tracks.remove(existing_track)
-                    unique_tracks.append(track)
-
-        # Sort final list by time in mix
-        return sorted(unique_tracks, key=lambda t: t.time_to_seconds())
+            existing = best_by_key.get(track_key)
+            if existing is None or track.confidence > existing.confidence:
+                best_by_key[track_key] = track
+        return sorted(best_by_key.values(), key=lambda t: t.time_to_seconds())
 
     def _create_track_group(self, track: Track) -> List[Track]:
         """Initialize a new track group with a single track."""

--- a/src/tracklistify/downloaders/spotify.py
+++ b/src/tracklistify/downloaders/spotify.py
@@ -3,7 +3,6 @@ Spotify audio downloader implementation.
 """
 
 # Standard library imports
-import asyncio
 import os
 import re
 import subprocess
@@ -248,7 +247,7 @@ class SpotifyDownloader(Downloader):
         """Clean filename by removing illegal characters."""
         return re.sub(ILLEGAL_CHARS_REGEX, ILLEGAL_CHARS_REPLACEMENT, filename)
 
-    def _set_metadata(self, file_path: str, metadata: Dict[str, Any]) -> None:
+    async def _set_metadata(self, file_path: str, metadata: Dict[str, Any]) -> None:
         """Set audio file metadata tags."""
         if self.format == AudioFormat.M4A:
             audio = MP4(file_path)
@@ -297,11 +296,8 @@ class SpotifyDownloader(Downloader):
         if metadata["album"].get("images"):
             cover_url = metadata["album"]["images"][0]["url"]
 
-            async def get_cover():
-                async with self._session.get(cover_url) as response:
-                    return await response.read()
-
-            cover_data = asyncio.run(get_cover())
+            async with self._session.get(cover_url) as response:
+                cover_data = await response.read()
             if self.format == AudioFormat.M4A:
                 audio["covr"] = [MP4Cover(cover_data, imageformat=MP4Cover.FORMAT_JPEG)]
 
@@ -392,7 +388,7 @@ class SpotifyDownloader(Downloader):
                 temp_path.rename(output_path)
 
             # Set metadata
-            self._set_metadata(output_path, metadata)
+            await self._set_metadata(output_path, metadata)
 
             logger.info(
                 f"Downloaded: {metadata['name']} by {metadata['artists'][0]['name']}"

--- a/src/tracklistify/downloaders/ytdlp.py
+++ b/src/tracklistify/downloaders/ytdlp.py
@@ -5,7 +5,6 @@ yt-dlp video downloader implementation.
 # Standard library imports
 import asyncio
 import os
-import tempfile
 import time
 from pathlib import Path
 from typing import Optional
@@ -163,32 +162,6 @@ class YtDlpDownloader(Downloader):
             elapsed = time.monotonic() - self._pp_started_at
             logger.info(f"Post-processing done in {elapsed:.1f}s")
             self._pp_started_at = None
-
-    def get_ydl_opts(self) -> dict:
-        """Get yt-dlp options with current configuration."""
-        # Prefer the per-invocation temp dir from AsyncApp; fall back to
-        # config (legacy callers) or system temp (last resort).
-        temp_dir = self.temp_dir or self.config.temp_dir or tempfile.gettempdir()
-
-        # Ensure temp directory exists
-        os.makedirs(temp_dir, exist_ok=True)
-
-        return {
-            "format": "bestaudio/best",
-            "postprocessors": [
-                {
-                    "key": "FFmpegExtractAudio",
-                    "preferredcodec": self.format,
-                    "preferredquality": self.quality,
-                }
-            ],
-            "ffmpeg_location": self.ffmpeg_path,
-            "outtmpl": os.path.join(temp_dir, "%(id)s.%(ext)s"),
-            "verbose": True,  # Always set to False to control output
-            "logger": self._logger,
-            "progress_hooks": [progress_hook],
-            "no_warnings": True,  # Suppress unnecessary warnings
-        }
 
     async def download(self, url: str) -> Optional[str]:
         """Download video from URL.

--- a/src/tracklistify/exporters/tracklist.py
+++ b/src/tracklistify/exporters/tracklist.py
@@ -15,6 +15,10 @@ from tracklistify.core.exceptions import ExportError
 from tracklistify.core.track import Track
 from tracklistify.utils.logger import get_logger
 
+# Precompiled sanitization patterns for clean_string (called per track).
+_INVALID_FILENAME_CHARS_RE = re.compile(r'[<>:"/\\|?*@]')
+_MULTISPACE_RE = re.compile(r"\s+")
+
 logger = get_logger(__name__)
 
 
@@ -66,11 +70,8 @@ class TracklistOutput:
 
         # Clean up special characters but preserve spaces and basic punctuation
         def clean_string(s: str) -> str:
-            # Replace invalid filename characters with spaces
-            s = re.sub(r'[<>:"/\\|?*@]', " ", s)
-            # Replace multiple spaces with single space
-            s = re.sub(r"\s+", " ", s)
-            # Strip leading/trailing spaces
+            s = _INVALID_FILENAME_CHARS_RE.sub(" ", s)
+            s = _MULTISPACE_RE.sub(" ", s)
             return s.strip()
 
         # Clean and format parts

--- a/src/tracklistify/providers/shazam.py
+++ b/src/tracklistify/providers/shazam.py
@@ -7,6 +7,7 @@ from typing import Any, Dict, Optional
 # Third-party imports
 from shazamio import Shazam
 
+from tracklistify.core.exceptions import ShazamError
 from tracklistify.providers.base import TrackIdentificationProvider
 
 # Local/package imports
@@ -95,8 +96,8 @@ class ShazamProvider(TrackIdentificationProvider):
         except asyncio.CancelledError:
             raise
         except Exception as e:
-            logger.error(f"Error during track identification: {e}")
-            return None
+            logger.error(f"Shazam identification failed: {e}")
+            raise ShazamError(f"Shazam identification failed: {e}", cause=e) from e
 
     async def enrich_metadata(self, track_info: Dict[str, Any]) -> Dict[str, Any]:
         """Enrich track metadata with additional information."""

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -44,9 +44,9 @@ class TestConfigSecurity:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", malicious)
             with pytest.raises(ValueError) as exc_info:
                 TrackIdentificationConfig()
-            assert "Invalid" in str(
-                exc_info.value
-            ), f"Expected ValueError for: {malicious}"
+            assert "Invalid" in str(exc_info.value), (
+                f"Expected ValueError for: {malicious}"
+            )
 
     def test_valid_numeric_formats_accepted(self, monkeypatch, clean_env):
         """Ensure valid numeric formats still work."""
@@ -59,9 +59,9 @@ class TestConfigSecurity:
         for env_value, expected in valid_configs:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", env_value)
             config = TrackIdentificationConfig()
-            assert (
-                config.segment_length == expected
-            ), f"Expected {expected}, got {config.segment_length}"
+            assert config.segment_length == expected, (
+                f"Expected {expected}, got {config.segment_length}"
+            )
 
     def test_valid_float_formats_accepted(self, monkeypatch, clean_env):
         """Ensure valid float formats work."""
@@ -74,9 +74,9 @@ class TestConfigSecurity:
         for env_value, expected in valid_configs:
             monkeypatch.setenv("TRACKLISTIFY_MIN_CONFIDENCE", env_value)
             config = TrackIdentificationConfig()
-            assert (
-                config.min_confidence == expected
-            ), f"Expected {expected}, got {config.min_confidence}"
+            assert config.min_confidence == expected, (
+                f"Expected {expected}, got {config.min_confidence}"
+            )
 
     def test_invalid_numeric_formats_rejected(self, monkeypatch, clean_env):
         """Ensure invalid numeric formats are rejected."""
@@ -93,9 +93,9 @@ class TestConfigSecurity:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", invalid)
             with pytest.raises(ValueError) as exc_info:
                 TrackIdentificationConfig()
-            assert "Invalid" in str(
-                exc_info.value
-            ), f"Expected ValueError for: {invalid}"
+            assert "Invalid" in str(exc_info.value), (
+                f"Expected ValueError for: {invalid}"
+            )
 
     def test_scientific_notation_not_needed(self, monkeypatch, clean_env):
         """Scientific notation should not be needed for our use case."""
@@ -198,9 +198,9 @@ class TestSecretMasking:
             assert test_secret not in log_text, "Secret exposed in logs!"
 
             # Masked value should appear
-            assert (
-                "sup*****456" in log_text or "SPOTIFY_CLIENT_SECRET" in log_text
-            ), "Masked value or key name should appear"
+            assert "sup*****456" in log_text or "SPOTIFY_CLIENT_SECRET" in log_text, (
+                "Masked value or key name should appear"
+            )
 
             # Non-sensitive value should appear
             assert "true" in log_text, "Non-sensitive value should appear"

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -44,9 +44,9 @@ class TestConfigSecurity:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", malicious)
             with pytest.raises(ValueError) as exc_info:
                 TrackIdentificationConfig()
-            assert "Invalid" in str(exc_info.value), (
-                f"Expected ValueError for: {malicious}"
-            )
+            assert "Invalid" in str(
+                exc_info.value
+            ), f"Expected ValueError for: {malicious}"
 
     def test_valid_numeric_formats_accepted(self, monkeypatch, clean_env):
         """Ensure valid numeric formats still work."""
@@ -59,9 +59,9 @@ class TestConfigSecurity:
         for env_value, expected in valid_configs:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", env_value)
             config = TrackIdentificationConfig()
-            assert config.segment_length == expected, (
-                f"Expected {expected}, got {config.segment_length}"
-            )
+            assert (
+                config.segment_length == expected
+            ), f"Expected {expected}, got {config.segment_length}"
 
     def test_valid_float_formats_accepted(self, monkeypatch, clean_env):
         """Ensure valid float formats work."""
@@ -74,9 +74,9 @@ class TestConfigSecurity:
         for env_value, expected in valid_configs:
             monkeypatch.setenv("TRACKLISTIFY_MIN_CONFIDENCE", env_value)
             config = TrackIdentificationConfig()
-            assert config.min_confidence == expected, (
-                f"Expected {expected}, got {config.min_confidence}"
-            )
+            assert (
+                config.min_confidence == expected
+            ), f"Expected {expected}, got {config.min_confidence}"
 
     def test_invalid_numeric_formats_rejected(self, monkeypatch, clean_env):
         """Ensure invalid numeric formats are rejected."""
@@ -93,9 +93,9 @@ class TestConfigSecurity:
             monkeypatch.setenv("TRACKLISTIFY_SEGMENT_LENGTH", invalid)
             with pytest.raises(ValueError) as exc_info:
                 TrackIdentificationConfig()
-            assert "Invalid" in str(exc_info.value), (
-                f"Expected ValueError for: {invalid}"
-            )
+            assert "Invalid" in str(
+                exc_info.value
+            ), f"Expected ValueError for: {invalid}"
 
     def test_scientific_notation_not_needed(self, monkeypatch, clean_env):
         """Scientific notation should not be needed for our use case."""
@@ -121,6 +121,7 @@ class TestSecretMasking:
             "TRACKLISTIFY_SPOTIFY_TOKEN",
             "TRACKLISTIFY_SPOTIFY_CLIENT_SECRET",
             "TRACKLISTIFY_ACRCLOUD_ACCESS_KEY",
+            "TRACKLISTIFY_SHAZAM_PROXY",
         ]
 
         for key in sensitive:
@@ -197,9 +198,9 @@ class TestSecretMasking:
             assert test_secret not in log_text, "Secret exposed in logs!"
 
             # Masked value should appear
-            assert "sup*****456" in log_text or "SPOTIFY_CLIENT_SECRET" in log_text, (
-                "Masked value or key name should appear"
-            )
+            assert (
+                "sup*****456" in log_text or "SPOTIFY_CLIENT_SECRET" in log_text
+            ), "Masked value or key name should appear"
 
             # Non-sensitive value should appear
             assert "true" in log_text, "Non-sensitive value should appear"

--- a/tests/test_providers_shazam.py
+++ b/tests/test_providers_shazam.py
@@ -6,6 +6,7 @@ from unittest.mock import AsyncMock
 import pytest
 
 from tracklistify.config import clear_config, get_config
+from tracklistify.core.exceptions import ShazamError
 from tracklistify.providers.shazam import ShazamProvider
 
 
@@ -54,5 +55,29 @@ async def test_shazam_no_proxy_env_forwards_none(monkeypatch):
         )
 
         recognize.assert_awaited_once_with("segment.mp3", proxy=None)
+    finally:
+        clear_config()
+
+
+@pytest.mark.asyncio
+async def test_shazam_raises_on_recognize_error(monkeypatch):
+    """Errors from recognize() must raise ShazamError, not return None.
+
+    identification.py records success=False only when identify_track
+    raises — swallowing into None defeated the circuit breaker.
+    """
+    monkeypatch.setenv("TRACKLISTIFY_SHAZAM_COOLDOWN_SECONDS", "0")
+    clear_config()
+
+    try:
+        get_config(force_refresh=True)
+        provider = ShazamProvider()
+        recognize = AsyncMock(side_effect=RuntimeError("connection refused"))
+        monkeypatch.setattr(provider.shazam, "recognize", recognize)
+
+        with pytest.raises(ShazamError, match="connection refused"):
+            await provider.identify_track(
+                SimpleNamespace(file_path="segment.mp3", start_time=0)
+            )
     finally:
         clear_config()

--- a/tests/test_providers_shazam.py
+++ b/tests/test_providers_shazam.py
@@ -29,3 +29,30 @@ async def test_shazam_proxy_env_is_forwarded_to_recognize(monkeypatch):
         recognize.assert_awaited_once_with("segment.mp3", proxy=proxy)
     finally:
         clear_config()
+
+
+@pytest.mark.asyncio
+async def test_shazam_no_proxy_env_forwards_none(monkeypatch):
+    """When TRACKLISTIFY_SHAZAM_PROXY is unset, recognize gets proxy=None.
+
+    This locks the empty-string-to-None coercion at shazam.py:46 — if a
+    future edit drops the ``or None``, recognize would receive proxy=""
+    instead of None, which is the wrong no-proxy sentinel.
+    """
+    monkeypatch.delenv("TRACKLISTIFY_SHAZAM_PROXY", raising=False)
+    monkeypatch.setenv("TRACKLISTIFY_SHAZAM_COOLDOWN_SECONDS", "0")
+    clear_config()
+
+    try:
+        get_config(force_refresh=True)
+        provider = ShazamProvider()
+        recognize = AsyncMock(return_value={"matches": []})
+        monkeypatch.setattr(provider.shazam, "recognize", recognize)
+
+        await provider.identify_track(
+            SimpleNamespace(file_path="segment.mp3", start_time=0)
+        )
+
+        recognize.assert_awaited_once_with("segment.mp3", proxy=None)
+    finally:
+        clear_config()

--- a/tests/test_providers_shazam.py
+++ b/tests/test_providers_shazam.py
@@ -36,9 +36,9 @@ async def test_shazam_proxy_env_is_forwarded_to_recognize(monkeypatch):
 async def test_shazam_no_proxy_env_forwards_none(monkeypatch):
     """When TRACKLISTIFY_SHAZAM_PROXY is unset, recognize gets proxy=None.
 
-    This locks the empty-string-to-None coercion at shazam.py:46 — if a
-    future edit drops the ``or None``, recognize would receive proxy=""
-    instead of None, which is the wrong no-proxy sentinel.
+    This locks the empty-string-to-None coercion — if a future edit drops
+    the ``or None``, recognize would receive proxy="" instead of None,
+    which is the wrong no-proxy sentinel.
     """
     monkeypatch.delenv("TRACKLISTIFY_SHAZAM_PROXY", raising=False)
     monkeypatch.setenv("TRACKLISTIFY_SHAZAM_COOLDOWN_SECONDS", "0")


### PR DESCRIPTION
## Summary

Follow-up PR addressing the #63 review findings, the Shazam error-swallowing debt surfaced by the error-handling review, and the salvageable bug fixes from #50.

## Changes

### `fix(shazam): raise ShazamError instead of swallowing to None`
The broad `except Exception: return None` in `shazam.py` swallowed all errors (proxy failures, connection errors, parse errors) into `None`, making them indistinguishable from "no match found." This **defeated the circuit breaker** wired in #53 — `identification.py` calls `record_result(success=True)` on every `None` return, so Shazam failures never tripped the breaker.

Now raises `ShazamError` on unexpected exceptions, matching ACRCloud's typed-exception pattern. Legitimate "no match" returns stay as `return None` (those are correct successes). `identification.py` already calls `record_result(success=False)` when `identify_track` raises — no change needed there.

### `fix(spotify): make _set_metadata async to avoid asyncio.run in loop`
`_set_metadata` called `asyncio.run(get_cover())` from inside the running event loop of `async def download()`, raising `RuntimeError` whenever a track had cover art. Now async, awaits the cover fetch directly.

### `test(shazam): add default-path and sensitive-key tests`
Closes the two coverage gaps from #63:
- Default-path test: locks the empty-string-to-None coercion (`recognize` gets `proxy=None` when unset).
- `TRACKLISTIFY_SHAZAM_PROXY` added to the sensitive-keys assertion in `test_config_security.py`.

### `perf: O(n) track dedup, cache size-reuse, precompiled regexes, remove dead code`
Four behavior-preserving cleanups salvaged from #50:
- `get_unique_tracks` O(n²) → O(n) via single-pass dict.
- `SizeStrategy.update_metadata` short-circuits when size already computed.
- `clean_string` regexes hoisted to module-level precompiled patterns.
- Dead `get_ydl_opts()` removed from `ytdlp.py` (zero callers; `mixcloud.py` has its own).

## Verification
- 393 tests pass (390 baseline + 3 new)
- `ruff check` / `ruff format` clean
- `.env.example` drift check clean
- Error-path test proves Shazam now raises `ShazamError` instead of returning `None`

## Related
- Closes the #63 review follow-ups
- Supersedes the salvageable parts of #50 (which can be closed after this merges)
- The Shazam error-handling fix was identified by the `/pr-review-toolkit:review-pr` run on #63