### PR TITLE
docs: unknowns register + specs for the two unblocked P2 features

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -172,5 +172,8 @@ poetry.lock
 .tracklistify/
 examples/
 dev/
+# ...but not the committed spec/plan docs. The bare `dev/` above matches at any
+# depth, so without this negation `docs/dev/*-spec.md` is silently untracked.
+!docs/dev/
 docs/temp/
 coverage.json

--- a/docs/BACKLOG.md
+++ b/docs/BACKLOG.md
@@ -4,7 +4,41 @@ From the 2026-07 handoff audit. Ordered by priority. Each item has enough
 context to be picked up cold. "Fixed" items are listed at the bottom so
 nobody re-audits them from scratch.
 
+---
+
+## Open unknowns
+
+The items below are blocked on something other than effort. Without this
+register the distinction is invisible — it is buried in prose inside the P2/P3
+entries, so "MusicBrainz enrichment" and "Spotify enrichment" look like the
+same size of job when only one of them is actually unblocked.
+
+Three kinds of blocker: **measurement** (nobody has the number yet),
+**decision** (nobody has chosen yet), **external** (someone outside the project
+has to say yes).
+
+| ID | Question | Kind | Blocks | How it gets resolved |
+|---|---|---|---|---|
+| U1 | What is the overall ISRC presence rate in Shazam responses? | measurement | Sizes both enrichment items | The per-run isrc/search/none counter shipped by the Spotify spec. Current evidence is n=1 set: 7 of the 8 link-less tracks in a 20-track run carried an ISRC — that is a rate among *link-less* tracks, not the overall rate |
+| U2 | What fraction of ISRCs resolve to a Spotify track? | measurement | P2 Spotify payoff estimate (the 12/20 → ~19/20 claim) | Same counter |
+| U3 | How often does title/artist search return the *wrong* track for underground techno? | measurement | Trusting the P2 Spotify fallback path | Not resolvable up front. The Spotify spec records `spotify_match: "isrc"\|"search"` per track, so fuzzy hits are auditable in real output instead of silently presented as fact |
+| U4 | Flat per-platform keys or a nested `links` object in `Track.metadata`? | decision | P3 schema item | **Decided 2026-08-02 — nested `metadata.links`.** See `docs/dev/2026-08-02-spotify-link-enrichment-spec.md` unit E |
+| U5 | How well does MusicBrainz cover underground-electronic ISRCs? | measurement | P3 MusicBrainz — if coverage is low this buys little | Offline probe over a real `tracklist.json` once U1/U2 have produced ISRCs to probe with. Cheap, keyless, and worth doing before writing any MusicBrainz code |
+| U6 | Is the non-distinguishing title-suffix allowlist complete? | measurement | P2 dedup | Not resolvable up front, and deliberately so: the dedup spec defaults to *keep*, so an incomplete allowlist costs a visible duplicate row, never a silent deletion. Widen it from observed output over time |
+| U7 | RapidAPI Shazam: PCM conversion cost, metadata parity with shazamio, per-request price at ~216 segments/run, bot-defender reliability | external | P3 RapidAPI | Needs a paid key to answer any of it |
+| U8 | Will Beatport grant partner access? | external | P3 Beatport | Commercial-use review through the Partner Portal. No code path exists without it, and the known public-client-ID workaround is not shippable |
+| U9 | What is the real scope of the Spotify authorization-code + PKCE flow? | decision | Playlist export (`exporters/spotify.py`) | Unscoped. Client-credentials tokens can never reach `/me/playlists`, so this is a feature project, not a wiring task |
+| U10 | Should a `download_quality` / `download_format` change invalidate the download cache? | decision | P4 cache debt | Unowned behavior decision. Today those fields are not wired through the factory and are absent from the cache key, so a re-run at a different quality serves the old file |
+
+**Unblocked right now:** the two P2 items. Both have specs in `docs/dev/`.
+Everything else in this table is waiting on a measurement that those specs
+produce, or on someone outside the project.
+
+---
+
 ## P2 — bracketed/parenthetical title variants survive dedup as separate rows
+
+**Spec:** `docs/dev/2026-08-02-dedup-title-variants-spec.md`
 
 Identity requires titles to be **exactly equal** after normalization
 (`_tracks_match`), so a track detected under two title spellings emits two
@@ -62,6 +96,9 @@ Jaccard threshold — that is a different axis and would reintroduce the
 collab-bridge data loss (see `docs/playbooks/changing-dedup.md` rule 1b).
 
 ## P2 — Spotify enrichment is built but unreachable
+
+**Spec:** `docs/dev/2026-08-02-spotify-link-enrichment-spec.md` (also decides
+the P3 link-schema item below — unknown U4)
 
 `SpotifyProvider` (search/enrich, client-credentials auth) works but no
 pipeline stage calls `enrich_metadata`. The natural hook: after
@@ -205,6 +242,14 @@ and PKCE flow make it closer in shape to the Spotify *playlist export*
 problem than to the simple client-credentials enrichment above.
 
 ## P3 — decide the `metadata` link schema before more platforms land
+
+**Decided 2026-08-02 (unknown U4): nested `metadata.links`.** Specified in
+`docs/dev/2026-08-02-spotify-link-enrichment-spec.md` unit E, which lands it
+alongside the Spotify enrichment as this entry recommends. The flat keys are
+removed rather than aliased, and `links.spotify` is canonical-only — the
+Shazam-supplied search URLs keep distinct `spotify_search` / `deezer_search`
+keys so a consumer can tell a resolved track link from a search. The rest of
+this entry is retained as the rationale.
 
 `Track.metadata` currently carries flat, per-platform keys: `shazam_url`,
 `apple_music_id`, `spotify_search_url`, `deezer_search_url`. That is fine

--- a/docs/dev/2026-08-02-dedup-title-variants-spec.md
+++ b/docs/dev/2026-08-02-dedup-title-variants-spec.md
@@ -1,0 +1,294 @@
+# Spec — dedup: merge non-distinguishing title variants
+
+**Date:** 2026-08-02
+**Backlog item:** `docs/BACKLOG.md` → "P2 — bracketed/parenthetical title
+variants survive dedup as separate rows"
+**Status:** specified, not implemented
+**Required reading before implementing:** `docs/playbooks/changing-dedup.md`
+
+---
+
+## Goal
+
+Two detections of the same recording, one segmentation step apart with matching
+artists, must emit **one** row when the only difference between their titles is
+a non-distinguishing bracketed suffix — and must still emit **two** rows when
+the suffix names a different recording.
+
+Confirmed on real output (backlog table):
+
+| Time | Title A | Title B | Wanted |
+|---|---|---|---|
+| 08:20 / 09:10 | `Meet Her At The Love Parade (feat. Kiki Solvej)` | `Meet Her At The Love Parade (Mixed)` | 1 row |
+| 57:30 / 58:20 | `Outside World (Club Mix)` | `Outside World` | 1 row |
+| — | `Stereo Murder [Live At Tomorrowland]` | `Stereo Murder` | 1 row |
+| — | `Berghain` | `Berghain (Remix)` | 2 rows |
+
+Both merge pairs are ~50 s apart with matching artists, so the proximity and
+artist gates already agree they belong together. Only the title check splits
+them.
+
+## Non-goals
+
+- Fuzzy title similarity ratios. See "Why not a threshold" below.
+- Any change to the artist axis or to `_ARTIST_THRESHOLD`.
+- Any change to what is *displayed*. This is a comparison-only change.
+- Markdown / M3U / JSON output changes.
+
+---
+
+## Why not a threshold
+
+No single similarity ratio separates the merge cases from the separate cases.
+`"Berghain"` vs `"Berghain (Remix)"` (must split) and `"Outside World"` vs
+`"Outside World (Club Mix)"` (should merge) are the same edit distance;
+`docs/playbooks/changing-dedup.md:149-156` records that `"Berghain (Remix)"`
+vs `"Berghain (Radio Edit)"` and `"Berghain"` vs `"Berghain (Remix)"` both
+score 0.727 with opposite correct answers.
+
+The distinguishing information is **semantic**, not metric: `(Mixed)`,
+`(Club Mix)`, `(Radio Edit)`, `(Extended Mix)`, `(feat. X)`, `[Live At …]` are
+usually the same recording under different Shazam spellings, while `(Remix)`
+and a named `(Someone Remix)` are a genuinely different track. So the rule is a
+curated allowlist, not a tuned number.
+
+---
+
+## Approach
+
+Add `_strip_title_variant(title: str) -> str` to
+`src/tracklistify/core/track.py`, placed after `_normalize_token`
+(`track.py:55-65`). It is consumed by `_tracks_match` (`track.py:86-95`) and by
+nothing else.
+
+### Four load-bearing decisions
+
+**D1 — Strip on the raw title, before normalizing.**
+`_normalize_token` maps punctuation to spaces at `track.py:64`
+(`re.sub(r"[^\w\s]", " ", s)`), so after it has run there are no delimiters
+left to anchor on:
+
+```
+"Stereo Murder [Live At Tomorrowland]" -> "stereo murder live at tomorrowland"
+"Outside World (Club Mix)"             -> "outside world club mix"
+```
+
+A post-normalize stripper would have to substring-match, which eats a track
+genuinely titled `Club Mix`. The helper therefore matches `\(([^()]*)\)` and
+`\[([^\[\]]*)\]` on the raw string and normalizes the remainder afterwards.
+This mirrors the ordering invariant `_artist_tokens` already relies on at
+`track.py:68-74` (split before normalize, so separators survive).
+
+**D2 — Default is KEEP.**
+Only suffixes on the allowlist are stripped; anything unrecognized is retained.
+An incomplete allowlist therefore produces a *visible duplicate row*, never a
+silent deletion — the direction `docs/playbooks/changing-dedup.md` rule 1b
+always chooses.
+
+**D3 — Comparison only.**
+`_rep_key` (`track.py:98-120`) and every output path keep reading raw
+`track.song_name`. The displayed name stays exactly what the provider returned.
+`_rep_key` is not modified.
+
+**D4 — Empty-result fallback.**
+If stripping leaves nothing but whitespace, return the original title. Without
+this, a track titled `(Mixed)` and one titled `(Club Mix)` both reduce to the
+empty string and merge.
+
+### Exact rule set
+
+Each bracketed group's inner text is normalized with `_normalize_token`, then
+tested in this order. **The keep-list is checked first**, so widening the
+drop-lists later cannot quietly swallow a remix.
+
+1. **Never strip** — inner text contains any of:
+   `remix`, `bootleg`, `edit by`, `vip`
+2. **Strip** — inner text is exactly one of:
+   `mixed`, `club mix`, `extended mix`, `original mix`, `radio edit`,
+   `radio mix`, `extended`, `original`
+3. **Strip** — inner text starts with any of:
+   `live at `, `feat `, `ft `, `featuring `
+4. **Otherwise keep.**
+
+(Prefixes are written post-normalization: `"feat. Kiki Solvej"` normalizes to
+`"feat kiki solvej"`, so the prefix to match is `"feat "`, not `"feat. "`.)
+
+An empty group (`"Foo ()"`) is dropped — it is noise under either reading.
+
+### Reference implementation shape
+
+Not binding on style, but the semantics below are binding.
+
+```python
+_TITLE_GROUP_RE = re.compile(r"\(([^()]*)\)|\[([^\[\]]*)\]")
+
+_SUFFIX_KEEP_MARKERS = ("remix", "bootleg", "edit by", "vip")
+
+_SUFFIX_DROP_EXACT = frozenset({
+    "mixed", "club mix", "extended mix", "original mix",
+    "radio edit", "radio mix", "extended", "original",
+})
+
+_SUFFIX_DROP_PREFIXES = ("live at ", "feat ", "ft ", "featuring ")
+
+
+def _strip_title_variant(title: str) -> str:
+    def _decide(m: "re.Match[str]") -> str:
+        raw = m.group(1) if m.group(1) is not None else m.group(2)
+        inner = _normalize_token(raw)
+        if not inner:
+            return ""
+        if any(marker in inner for marker in _SUFFIX_KEEP_MARKERS):
+            return m.group(0)
+        if inner in _SUFFIX_DROP_EXACT or inner.startswith(_SUFFIX_DROP_PREFIXES):
+            return ""
+        return m.group(0)
+
+    stripped = _TITLE_GROUP_RE.sub(_decide, title)
+    return stripped if stripped.strip() else title
+```
+
+`_tracks_match`'s title clause becomes
+`_normalize_token(_strip_title_variant(t1.song_name)) == _normalize_token(_strip_title_variant(t2.song_name))`.
+The artist clause is untouched.
+
+### Worked cases
+
+| Input | After strip + normalize |
+|---|---|
+| `Meet Her At The Love Parade (feat. Kiki Solvej)` | `meet her at the love parade` |
+| `Meet Her At The Love Parade (Mixed)` | `meet her at the love parade` |
+| `Outside World (Club Mix)` | `outside world` |
+| `Outside World` | `outside world` |
+| `Stereo Murder [Live At Tomorrowland]` | `stereo murder` |
+| `Berghain (Remix)` | `berghain remix` |
+| `Berghain` | `berghain` |
+| `Outside World (Adam Beyer Remix)` | `outside world adam beyer remix` |
+| `Foo (Kiki's Extended Remix)` | `foo kiki s extended remix` (keep-list beats `extended`) |
+| `Club Mix` (real title, no brackets) | `club mix` (no group to match) |
+| `(Mixed)` | `mixed` (D4 fallback) |
+
+Nested parentheses are not handled by `[^()]*`; a non-match falls through to
+"keep", which is the safe default.
+
+---
+
+## Do not touch the artist axis
+
+`_ARTIST_THRESHOLD = 0.34` (`track.py:38`) sits in an empirical gap — all
+observed merge cases score ≥ 0.50, all separate cases 0.00 — and existing tests
+bracket it to within 0.067 (`tests/test_track_matcher.py:217` must-not-merge at
+0.333, `:232` must-merge at 0.40). Loosening it to reach these cases
+reintroduces the collab-bridge data loss described in
+`docs/playbooks/changing-dedup.md` rule 1b, where a collaboration credit
+transitively bridges two distinct artists and a later distinct play is deleted
+outright. The backlog rules this out explicitly (lines 60–62).
+
+---
+
+## Performance requirement
+
+`_tracks_match` runs once per active cluster per candidate track. This change
+adds one regex pass and one extra `_normalize_token` per side per call.
+
+The implementation **must** run the scale probe from
+`docs/playbooks/changing-dedup.md` (verification section) and record the
+before/after delta. Expected budget: ~1.5 / 7 / 13 ms at n = 216 / 1000 / 2000.
+Over ~100 ms at n = 2000 means identity matching is scanning cluster members
+instead of anchoring on `cluster[0]` — a different bug.
+
+**The probe must use repeated detections.** The playbook records an earlier
+probe that generated all-distinct titles, left every cluster at size 1, and
+certified a quadratic implementation as linear.
+
+If the probe regresses beyond the budget, memoize the strip+normalize composite
+with a bounded `functools.lru_cache` keyed on the raw title. Do not memoize
+speculatively — measure first.
+
+---
+
+## Tests
+
+All in `tests/test_track_matcher.py::TestDedupInvariants`. Build tracks with
+the existing `_t(name, artist, secs, conf=80.0)` helper
+(`test_track_matcher.py:269-278`). The `config` fixture pins
+`segment_length = 60`, `overlap_duration = 10`, `time_threshold = 0`, so the
+derived window is 100 s and 50 s apart is exactly one step.
+
+Both poles are mandatory — `docs/playbooks/changing-dedup.md`, "procedure for a
+rule change", step 2.
+
+### Must merge (1 row)
+
+1. `Meet Her At The Love Parade (feat. Kiki Solvej)` @ 08:20 vs
+   `Meet Her At The Love Parade (Mixed)` @ 09:10, same artist.
+2. `Outside World (Club Mix)` @ 57:30 vs `Outside World` @ 58:20, same artist.
+3. `Stereo Murder [Live At Tomorrowland]` vs `Stereo Murder`, 50 s apart —
+   square brackets, so a paren-only stripper fails this one.
+
+### Must separate (2 rows)
+
+4. `Berghain` vs `Berghain (Remix)`, same artist, 50 s apart.
+   **This pole does not exist in the suite today.** All six
+   `"Berghain (Remix)"` literals currently in the file (`:190`, `:196`, `:341`,
+   `:342`, `:437`, `:438`) carry the suffix on *both* sides of the comparison,
+   so they merge with or without stripping — the existing suite cannot catch an
+   over-aggressive stripper.
+5. `Outside World (Club Mix)` vs `Outside World (Adam Beyer Remix)` — a named
+   remix, the keep-list's main job.
+6. A track titled `Club Mix` vs one titled `Mixed` (no brackets on either) —
+   proves the stripper anchors on delimiters and does not substring-match.
+7. A track titled `(Mixed)` vs one titled `(Club Mix)` — the D4 fallback.
+
+### Non-regression
+
+8. The representative keeps its raw title: for case 1 the 08:20 detection wins
+   by `_rep_key`, so the emitted `song_name` is
+   `Meet Her At The Love Parade (feat. Kiki Solvej)`, not a stripped form.
+9. These must still pass unchanged: `test_artist_variant_merge_berghain`
+   (`:185`), `test_similar_song_different_artist`, the two Jaccard-bound tests
+   (`:217`, `:232`), and `test_f07_is_similar_to_agrees_with_dedup_predicate`
+   (`:435`) — `Track.is_similar_to` delegates to `_tracks_match`
+   (`track.py:156-163`) and must keep agreeing with it.
+
+---
+
+## Interaction with the Spotify enrichment spec
+
+`docs/dev/2026-08-02-spotify-link-enrichment-spec.md` enriches tracks after
+`get_unique_tracks()`. Stripping is **comparison-only** (D3), so enrichment
+looks up Spotify with the raw `song_name` — the provider's own spelling — not a
+stripped form. Both specs state this.
+
+The two changes compose cleanly and can land in either order: this one reduces
+the number of unique tracks, which only reduces the number of enrichment calls.
+
+---
+
+## Documentation this change invalidates
+
+Update at implementation time:
+
+- `docs/playbooks/changing-dedup.md:149-156` — "Titles are exact-after-normalize,
+  deliberately" becomes exact-after-strip-then-normalize; keep the
+  no-fuzzy-ratio rationale, it is still correct.
+- `docs/ARCHITECTURE.md` — implicit contract "same track iff normalized titles
+  equal AND artist Jaccard ≥ 0.34".
+- `CLAUDE.md:50` — the dedup landmine bullet.
+- `docs/BACKLOG.md` — move the P2 entry to the Fixed table; the "Known
+  limitation (accepted, not fixed)" note under the 2026-07 batch is superseded
+  for the allowlisted suffixes and must say so.
+- `docs/CHANGELOG.md` — `[Unreleased]`, user-visible output change.
+
+---
+
+## Success criteria
+
+1. All eight new tests (cases 1–8) pass; the full suite shows no new failures
+   against the recorded baseline.
+2. The scale probe is within budget, with the delta recorded in the PR.
+3. `uv run ruff check src/ tests/ scripts/`,
+   `uv run ruff format --check src/ tests/ scripts/`, and
+   `uv run python scripts/generate_env_example.py --check` all pass.
+4. No diff in `_rep_key`, `_artists_match`, `_ARTIST_THRESHOLD`,
+   `get_unique_tracks`, or any exporter.

--- a/docs/dev/2026-08-02-spotify-link-enrichment-spec.md
+++ b/docs/dev/2026-08-02-spotify-link-enrichment-spec.md
@@ -1,0 +1,416 @@
+# Spec — Spotify canonical links + `metadata.links` schema
+
+**Date:** 2026-08-02
+**Backlog items:** `docs/BACKLOG.md` → "P2 — Spotify enrichment is built but
+unreachable" and "P3 — decide the `metadata` link schema before more platforms
+land" (unknown **U4**, decided here)
+**Status:** specified, not implemented
+**Required reading before implementing:** `docs/PLAYBOOKS.md` ("Add a config
+option"), `docs/ARCHITECTURE.md` (invariant I6, load-bearing #2 and #5)
+
+---
+
+## Goal
+
+Every unique track in `tracklist.json` carries a canonical
+`https://open.spotify.com/track/<id>` link wherever one can be found, and
+`Track.metadata` moves from flat per-platform keys to a nested `links` object
+before a third link source lands.
+
+### Why now, with numbers
+
+Measured on a fresh-cache run, 2026-08-01, 20-track Tomorrowland set
+(recorded in the backlog):
+
+- Shazam supplied a Spotify *search* URL for **12/20** tracks. `hub.providers`
+  is simply absent from ~40% of responses, and it varies between calls for the
+  same audio.
+- **7 of the 8** tracks missing a link **do carry an ISRC**.
+
+An ISRC-first lookup therefore takes link coverage from 12/20 to roughly 19/20.
+That is the concrete argument for building this.
+
+`SpotifyProvider` already implements search and client-credentials auth; no
+pipeline stage calls it. `_save_json` already emits `Track.metadata` per track
+(`exporters/tracklist.py:159-167`, shipped 2026-08-01), so an enrichment hook is
+visible without further exporter work.
+
+## Non-goals
+
+- **Playlist export / authorization-code + PKCE** (unknown U9).
+  `exporters/spotify.py` calls `/me/playlists`, which a client-credentials token
+  can never access. That is a feature project, not a drive-by.
+- **MusicBrainz** (unknown U5 — gated on unmeasured coverage of
+  underground-electronic ISRCs). The enricher is nonetheless shaped so a second
+  source slots in later; see "Shape for a second source".
+- **Adding `spotify` to `KNOWN_PROVIDERS`.** It has no `identify_track`, so
+  `-p spotify` would crash and invariant I3 would fail.
+- Rescuing or deleting `downloaders/spotify.py` (separate P3 item).
+- Markdown / M3U rendering of metadata. Both build their own strings and ignore
+  `metadata`; extend only if a user asks.
+- Client-side scoring of fuzzy search results — see R7 for what replaces it.
+
+---
+
+## Requirements
+
+Each is independently testable.
+
+**R1.** `SpotifyProvider.search_track` returns `external_urls` and `isrc` in
+addition to its current keys.
+
+**R2.** `SpotifyProvider.search_by_isrc(isrc)` performs an exact ISRC lookup.
+
+**R3.** `ProviderFactory.get_spotify_provider()` returns a configured provider,
+or `None` when credentials are absent — it never raises for missing creds.
+
+**R4.** `IdentificationManager` enriches unique tracks after dedup, ISRC-first
+with a title/artist fallback.
+
+**R5.** Enrichment never fails a run. Every error path leaves the identified
+tracks intact and the run successful.
+
+**R6.** Every rate-limiter `acquire` is matched by a `release` in a `finally`,
+and every outcome is reported via `record_result`.
+
+**R7.** Each enriched track records **how** it was matched
+(`spotify_match: "isrc" | "search"`), and each run logs a summary count of
+`isrc` / `search` / `none`.
+
+**R8.** `Track.metadata` link keys move under a nested `links` object.
+
+**R9.** Enrichment is gated by `enrichment_enabled` (default `true`) and is a
+silent no-op when credentials are absent.
+
+---
+
+## Unit A — `search_track` returns the link fields
+
+`src/tracklistify/providers/spotify.py:148-200`.
+
+The return dict at lines 194–200 carries `spotify_id` but no `external_urls`.
+`get_track_details` does have `external_urls` (line 227) but is the wrong route:
+it names the id `id` rather than `spotify_id`, and it makes a second
+`audio-features` request that Spotify deprecated for new apps in Nov 2024, so
+it will 403 on any newly created client and the whole method re-raises.
+
+Add to the returned dict:
+
+```python
+"external_urls": top.get("external_urls") or {},
+"isrc": (top.get("external_ids") or {}).get("isrc"),
+```
+
+Use `.get()` for the new fields. The existing keys use bare subscripts
+(`top["id"]`, `top["album"]["release_date"]`) outside the `try`, so a malformed
+response already raises `KeyError`; do not widen that behavior, but do not
+extend it to the new optional fields either.
+
+Constraints:
+- The `MetadataProvider` ABC signature (`providers/base.py:83-89`) must not
+  change.
+- `tests/test_spotify_encapsulation.py` asserts method names and parameter
+  names by static analysis; adding return keys is safe, renaming is not.
+
+## Unit B — `search_by_isrc`
+
+New method on `SpotifyProvider`:
+
+```python
+async def search_by_isrc(self, isrc: str) -> Dict:
+```
+
+`GET search` with `params={"q": f"isrc:{isrc}", "type": "track", "limit": 1}`.
+Returns the same dict shape as `search_track` (so the caller has one shape to
+handle), or `{}` when there are no items.
+
+Error posture identical to its neighbours: re-raise `RateLimitError` and
+`AuthenticationError` unchanged, wrap everything else in `ProviderError`. Never
+swallow them into a generic `except Exception` — callers lose retry-after
+timing and 401-driven token refresh.
+
+This is an exact lookup, not a fuzzy one. That distinction is the whole point
+of preferring it (R7).
+
+## Unit C — factory accessor
+
+`src/tracklistify/providers/factory.py`.
+
+```python
+def get_spotify_provider(self) -> Optional["SpotifyProvider"]:
+```
+
+- Reads `TRACKLISTIFY_SPOTIFY_CLIENT_ID` and
+  `TRACKLISTIFY_SPOTIFY_CLIENT_SECRET` via `os.getenv`, following the ACRCloud
+  env-only pattern at `factory.py:73-97`. **Never** config-dataclass fields:
+  `_load_from_env` (`config/base.py:54-104`) auto-maps every field to
+  `TRACKLISTIFY_<UPPER>`, and dataclass fields leak through `repr()` and
+  validation error messages.
+- **Returns `None` when either credential is missing.** This is the one
+  deliberate departure from the ACRCloud branch, which raises `ConfigError`:
+  identification requires its provider, enrichment does not. Absent creds are a
+  skip, not an error.
+- Lazy-imports `SpotifyProvider` and caches the instance in `self.providers`
+  under a key that cannot collide with an identification provider name, so the
+  existing `close_all()` (`factory.py:106`) closes its aiohttp session. No new
+  lifecycle code.
+- `KNOWN_PROVIDERS` (`factory.py:17`) is **not** modified.
+
+## Unit D — the hook
+
+`src/tracklistify/utils/identification.py`.
+
+Called from `identify_tracks` immediately after
+`unique_tracks = self.track_matcher.get_unique_tracks()` (line 414):
+
+```python
+unique_tracks = self.track_matcher.get_unique_tracks()
+await self._enrich_tracks(unique_tracks)
+```
+
+**Post-dedup by design.** A 3 h mix has ~216 raw detections but ~22 unique
+tracks — a 10× cut in API calls — and it keeps the rate limiter out of the
+identification hot path. The call site sits outside the `AsyncExitStack` that
+wraps identification providers, so those are already closed; unrelated and
+correct.
+
+### Per-track algorithm
+
+Sequential, not `gather` — the volume is ~22 and concurrency buys nothing worth
+the added failure modes.
+
+1. Skip if `track.metadata.get("links", {}).get("spotify")` is already set
+   (idempotence; mirrors `enrich_metadata`'s own guard at `spotify.py:78`).
+2. **ISRC path** — if `track.metadata.get("isrc")`, call `search_by_isrc`.
+3. **Search path** — otherwise call
+   `search_track(title=track.song_name, artist=track.artist)`.
+   Use the **raw** `song_name`, i.e. what the provider returned. If
+   `docs/dev/2026-08-02-dedup-title-variants-spec.md` has landed, its suffix
+   stripping is comparison-only and must not be applied here.
+4. On a hit, set:
+   - `metadata["links"]["spotify"]` — prefer `result["external_urls"]["spotify"]`,
+     else construct `f"https://open.spotify.com/track/{result['spotify_id']}"`
+   - `metadata["spotify_id"]`
+   - `metadata["spotify_match"] = "isrc"` or `"search"`
+5. On no hit, leave the track untouched and count it as `none`.
+
+`enrich_metadata` (`spotify.py:75-99`) is **not** used: it is keyed on
+`title`/`artist` while a `Track` uses `song_name`, and it has no ISRC path. The
+hook calls `search_by_isrc` / `search_track` directly.
+
+### Match provenance (R7)
+
+`spotify_match` is how unknown **U3** ("how often does fuzzy search return the
+wrong track for underground techno?") gets answered without inventing a
+scoring heuristic: an exact ISRC hit and a best-effort search hit are recorded
+differently, so a consumer can see which links are trustworthy and the
+wrong-match rate becomes auditable from real output rather than guessed.
+
+The per-run summary log — counts of `isrc` / `search` / `none` — is the
+instrumentation for unknowns **U1** (overall ISRC presence rate) and **U2**
+(Spotify ISRC-lookup hit rate). Log at INFO when anything was enriched.
+
+### Rate limiting
+
+The wiring already exists: `spotify_max_rpm = 120` and
+`spotify_max_concurrent = 20` (`config/base.py:230-232`) are consumed by
+`RateLimiter.register_provider`, which already has a `spotify` branch
+(`utils/rate_limiter.py:126-132`).
+
+Follow the identification loop's pattern verbatim
+(`identification.py:375-407`):
+
+```python
+acquired = False
+try:
+    acquired = await limiter.acquire("spotify")
+    if not acquired:
+        continue
+    ...
+    limiter.record_result("spotify", success=True)
+except asyncio.CancelledError:
+    raise
+except Exception:
+    limiter.record_result("spotify", success=False)
+finally:
+    if acquired:
+        limiter.release("spotify")
+```
+
+Breaking the acquire/release pairing deadlocks every run after N requests
+(ARCHITECTURE load-bearing #2). Skipping `record_result` means the circuit
+breaker never learns and never opens (invariant I6).
+
+Enter the provider as an async context manager (`async with provider:`) —
+`MetadataProvider` defines `__aenter__`/`__aexit__` at `providers/base.py:113-117`,
+and `close()` is documented re-entrable, so the later `close_all()` closing it
+again is safe.
+
+### Error handling (R5)
+
+Same posture as the cache I/O at `identification.py:354-392`: best-effort,
+degrade, never abort.
+
+| Condition | Behavior |
+|---|---|
+| `AuthenticationError` | Warn once, disable enrichment for the remainder of the run |
+| `RateLimitError` | Warn, stop enriching, return tracks enriched so far |
+| Any other `Exception` | Debug log, continue to the next track |
+| `asyncio.CancelledError` | Re-raise, never swallowed |
+| No credentials | Debug log, return immediately, never touch the limiter |
+| `enrichment_enabled` false | Return immediately |
+
+### Config
+
+New field on `TrackIdentificationConfig` (`config/base.py`):
+
+```python
+enrichment_enabled: bool = True
+```
+
+`true` is safe as a default because the feature is a no-op without credentials.
+
+Per `docs/PLAYBOOKS.md` → "Add a config option":
+
+1. Add the field with its default; `TRACKLISTIFY_ENRICHMENT_ENABLED` then works
+   automatically.
+2. Assign it to a new **"Metadata enrichment"** section in
+   `scripts/generate_env_example.py::FIELD_SECTIONS`, with an `INLINE_COMMENTS`
+   entry. Every public dataclass field must appear in exactly one section or the
+   script and the CI `drift` job hard-fail.
+3. Update `CREDENTIALS_BLOCK` in the same script — it currently tells readers
+   the Spotify credentials are "consumed only by the UNWIRED Spotify
+   downloader/exporter", which this change makes false.
+4. Regenerate: `uv run python scripts/generate_env_example.py`.
+
+Env-var truthiness is lowercase `true`/`false`.
+
+### Shape for a second source
+
+Structure `_enrich_tracks` so the per-source logic (resolve provider → look up
+one track → write into `metadata["links"]`) is separable from the loop
+scaffolding (gating, limiter pairing, error posture, summary counting). A
+MusicBrainz enricher (unknown U5) then adds a source without touching the
+scaffolding. Do not build an abstract base class or a registry for one
+implementation — just keep the seam obvious.
+
+## Unit E — `metadata.links` schema (decides U4)
+
+In `_extra_metadata` (`utils/identification.py:81-123`), the single parse point
+for provider extras.
+
+```json
+"metadata": {
+  "isrc": "USABC1234567",
+  "album": "...", "label": "...", "release_date": "...", "genres": ["..."],
+  "shazam_id": "...", "apple_music_id": "...", "artwork_url": "...",
+  "spotify_id": "...", "spotify_match": "isrc",
+  "links": {
+    "shazam": "...",
+    "spotify": "https://open.spotify.com/track/...",
+    "spotify_search": "...",
+    "deezer_search": "..."
+  }
+}
+```
+
+Decisions:
+
+- **`links.spotify` is canonical-only.** The Shazam-supplied search URLs keep
+  distinct `spotify_search` / `deezer_search` keys rather than being conflated
+  with a real track URL. A consumer must be able to tell "this resolves to the
+  track" from "this runs a search".
+- **Flat `shazam_url` / `spotify_search_url` / `deezer_search_url` are
+  removed**, not aliased. Four flat keys is fine; eight is the problem the
+  backlog flags, and migrating costs less now than after a third source lands.
+- The existing falsy-drop at `identification.py:123` extends to dropping an
+  empty `links` object, so a track with no links has no `links` key at all.
+- **`apple_music_id` stays flat.** We hold an id, not a URL; this spec does not
+  invent an Apple URL format.
+
+Blast radius is small because `providers/shazam.py`'s payload keys
+(`shazam.py:228-258`) are untouched — only the parse point changes.
+
+Consumers to update:
+
+- `tests/test_identification_utils.py:268,282` — asserts `spotify_search_url`
+  survives `_extra_metadata`.
+- `tests/test_providers_shazam.py` — the `spotify_search_url` assertions. Note
+  `_web_search_url` and the provider payload keys themselves do not change.
+- `docs/CHANGELOG.md` `[Unreleased]` — `tracklist.json` is the public surface,
+  so this is a consumer-visible change and must be called out as such.
+- `_save_json` (`exporters/tracklist.py:159-167`) emits `metadata` verbatim
+  with `default=str` and needs **no** change.
+
+---
+
+## Tests
+
+`tests/test_providers_spotify.py` mocks either by monkeypatching `_api_request`
+(line 18) or, for `_api_request` itself, with a hand-rolled
+`FakeResponse`/`FakeSession` injected over `_ensure_session` and
+`_get_access_token` (lines 96-124). Never hit the network.
+
+**Provider (Units A/B)**
+1. `search_track` surfaces `external_urls` and `isrc`, and still returns `{}`
+   on no items.
+2. `search_track` tolerates a response with neither `external_urls` nor
+   `external_ids`.
+3. `search_by_isrc` sends `q=isrc:<isrc>`, `type=track`, `limit=1` — assert the
+   captured params.
+4. `search_by_isrc` re-raises `RateLimitError` and `AuthenticationError`
+   unchanged.
+
+**Factory (Unit C)**
+5. Returns `None` with no creds (use `monkeypatch.delenv`), a `SpotifyProvider`
+   with both set, and `None` when only one is set.
+6. `"spotify" not in KNOWN_PROVIDERS`, and
+   `tests/test_handoff_invariants.py` I3 still passes untouched.
+
+**Hook (Unit D)**
+7. ISRC path is preferred when `metadata["isrc"]` exists — assert
+   `search_by_isrc` was called and `search_track` was not.
+8. Search fallback is used when there is no ISRC.
+9. `links["spotify"]` and `spotify_match` are set correctly on both paths, and
+   `external_urls["spotify"]` wins over the constructed URL when present.
+10. A track already carrying `links["spotify"]` is skipped.
+11. No creds → no-op, and the rate limiter is never touched.
+12. `enrichment_enabled = false` → no-op.
+13. `RateLimitError`, `AuthenticationError`, and a generic `Exception` each
+    leave `unique_tracks` intact and the run successful (R5).
+14. The limiter is released on every path including each exception path (R6) —
+    assert acquire/release call counts match.
+15. The run summary reports the isrc/search/none counts (R7).
+
+**Schema (Unit E)**
+16. `_extra_metadata` emits nested `links` with the Shazam-supplied URLs under
+    `shazam` / `spotify_search` / `deezer_search`.
+17. `_extra_metadata` omits `links` entirely when no link is present.
+18. `_save_json` round-trips a nested `links` object.
+
+---
+
+## Interaction with the dedup spec
+
+`docs/dev/2026-08-02-dedup-title-variants-spec.md` strips non-distinguishing
+title suffixes for **comparison only**. Enrichment therefore searches Spotify
+with the raw `song_name`, never a stripped form. Both specs state this.
+
+Order-independent: the dedup change only reduces the number of tracks reaching
+this hook.
+
+---
+
+## Success criteria
+
+1. All 18 tests pass; the full suite shows no new failures against the recorded
+   baseline.
+2. `uv run ruff check src/ tests/ scripts/`,
+   `uv run ruff format --check src/ tests/ scripts/`, and
+   `uv run python scripts/generate_env_example.py --check` all pass.
+3. With no Spotify credentials set, a normal run's behavior and output are
+   byte-identical to before the change apart from the `links` reshaping.
+4. With credentials set, a real run reports the isrc/search/none summary, and
+   `tracklist.json` carries `links.spotify` for the tracks that matched.
+5. `KNOWN_PROVIDERS` is unchanged and no Spotify credential appears on any
+   config dataclass.


### PR DESCRIPTION
## Why

`docs/BACKLOG.md` mixed three different kinds of item without distinguishing them: things **ready to build**, things blocked on an **external** gate (Beatport partner approval, a paid RapidAPI key), and things blocked on a **measurement or decision nobody has made**. That third category was invisible — the unknowns were buried in prose inside the P2/P3 entries, so a reader couldn't tell that MusicBrainz enrichment is gated on an unmeasured ISRC hit rate while Spotify enrichment is gated on nothing.

Two costs: unknowns got rediscovered from scratch on every pickup, and the two genuinely-unblocked features kept not getting built because they looked the same size as the blocked ones.

**Documentation only — no source changes.**

## What changed

### 1. Open-unknowns register (`docs/BACKLOG.md`)

New section listing U1–U10, each classified as **measurement** / **decision** / **external**, with what it blocks and how it gets resolved. Existing entries are retained; the two P2 items and the P3 schema item gained cross-links to their specs.

The conclusion the register makes explicit: only the two P2 items are unblocked. Everything else waits on a measurement those two produce, or on someone outside the project.

### 2. U4 decided — nested `metadata.links`

The P3 schema entry said to decide "when the Spotify enrichment item lands". It lands here: flat `shazam_url` / `spotify_search_url` / `deezer_search_url` are removed in favour of a nested `links` object. `links.spotify` is canonical-only — the Shazam-supplied search URLs keep distinct `spotify_search` / `deezer_search` keys so a consumer can tell a resolved track link from a search.

### 3. `docs/dev/2026-08-02-dedup-title-variants-spec.md`

Merges `Outside World (Club Mix)` with `Outside World` without merging `Berghain` into `Berghain (Remix)`. Four load-bearing decisions, each with its rationale:

- **Strip on the raw title, before normalizing** — `_normalize_token` maps punctuation to spaces, so a post-normalize stripper has no delimiter to anchor on and would substring-match, eating a track genuinely titled `Club Mix`.
- **Default is keep** — only allowlisted suffixes are stripped, so an incomplete allowlist costs a *visible duplicate row*, never a silent deletion.
- **Comparison only** — `_rep_key` and every output path keep the provider's original spelling.
- **Empty-result fallback** — otherwise `(Mixed)` and `(Club Mix)` both reduce to `""` and merge.

Includes the exact rule set verbatim, worked cases, the mandatory scale probe with its budget, and eight tests covering both poles. Notes that the must-not-merge pole doesn't exist in the suite today: all six `"Berghain (Remix)"` literals carry the suffix on both sides, so the current tests cannot catch an over-aggressive stripper.

### 4. `docs/dev/2026-08-02-spotify-link-enrichment-spec.md`

Canonical Spotify links via a post-`get_unique_tracks()` hook — ISRC-first, title/artist fallback. Backlog-measured payoff: link coverage 12/20 → ~19/20 on the reference set. Post-dedup means ~22 lookups per 3 h mix instead of ~216.

Five units (search-result link fields, `search_by_isrc`, an `Optional` factory accessor that returns `None` rather than raising for absent creds, the hook, the schema migration), with the acquire/release/`record_result` pattern spelled out verbatim, a never-fail-a-run error table, and 18 tests.

Records `spotify_match: "isrc" | "search"` per track and a per-run isrc/search/none summary — that's the instrumentation that answers U1, U2 and U3 from real output instead of a guessed heuristic.

### 5. `.gitignore` fix

The bare `dev/` pattern matches at any depth, including `docs/dev/`. Caught by `git status` after writing the specs — they'd have been silently untracked. Added a `!docs/dev/` negation rather than loosening `dev/` elsewhere.

## Verification

All gates run before and after; the change is docs-only, so identical results are the check.

| Gate | Result |
|---|---|
| `uv run python -m pytest -q` | `14 failed, 491 passed, 4 skipped` — **identical to the pre-change baseline** |
| `uv run ruff check src/ tests/ scripts/` | All checks passed |
| `uv run ruff format --check src/ tests/ scripts/` | 102 files already formatted |
| `uv run python scripts/generate_env_example.py --check` | `.env.example` is up to date |
| `git diff --stat main` | `docs/` + `.gitignore` only |

The 14 failures are pre-existing on `main` and environmental — `ffmpeg` is not installed in this container, so `AsyncApp.split_audio` and the yt-dlp tests fail at `get_ffmpeg_path()`. Unrelated to this change and unchanged by it.

Also ran the dev-flow spec self-review over both files: no TBD/TODO, no contradicting sections, exact values (suffix allowlist strings, `links` key names, `enrichment_enabled` default, Spotify query params) written verbatim so they can become the implementation plan's Global Constraints. Cross-checked the one place the specs touch the same data — stripping is comparison-only, so enrichment searches with the raw `song_name`; both specs say so.

## Not in scope

Any change under `src/`. Each spec gets its own approval and implementation pass.
