### PR TITLE
feat(enrichment): Spotify canonical links + nested metadata.links schema

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -66,6 +66,9 @@ TRACKLISTIFY_DOWNLOAD_FORMAT=mp3          # mp3 | flac | ...
 TRACKLISTIFY_DOWNLOAD_MAX_RETRIES=3
 TRACKLISTIFY_DOWNLOAD_CACHE_ENABLED=true
 
+# --- Metadata enrichment -----------------------------------------
+TRACKLISTIFY_ENRICHMENT_ENABLED=true      # resolve Spotify links post-dedup (no-op w/o creds)
+
 # --- API credentials (do NOT commit real values) ------------------------
 # These are read directly by provider modules via os.getenv, not via the
 # dataclass (secrets are deliberately kept off the config dataclass so they
@@ -76,8 +79,10 @@ TRACKLISTIFY_DOWNLOAD_CACHE_ENABLED=true
 # TRACKLISTIFY_ACR_ACCESS_SECRET=
 # TRACKLISTIFY_ACR_HOST=identify-eu-west-1.acrcloud.com
 #
-# Spotify credentials: currently consumed only by the UNWIRED Spotify
-# downloader/exporter (see docs/BACKLOG.md); not needed for normal runs.
+# Spotify credentials: consumed by the metadata-enrichment hook (resolves a
+# canonical Spotify track link per identified track via client-credentials
+# auth; gated by ENRICHMENT_ENABLED). The downloader/exporter is still
+# unwired (see docs/BACKLOG.md). Not needed for normal identification runs.
 # TRACKLISTIFY_SPOTIFY_CLIENT_ID=
 # TRACKLISTIFY_SPOTIFY_CLIENT_SECRET=
 # TRACKLISTIFY_SPOTIFY_COOKIES=~/.mozilla/firefox/profile/cookies.sqlite

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -9,6 +9,32 @@ Release dates are in YYYY-MM-DD format.
 
 ## [Unreleased]
 
+### Added
+
+- **Canonical Spotify track links via post-dedup enrichment.** After
+  deduplication, each unique track is enriched with a canonical
+  `https://open.spotify.com/track/<id>` link when Spotify credentials are
+  configured (`TRACKLISTIFY_SPOTIFY_CLIENT_ID`/`_SECRET`, client-credentials
+  auth). The lookup is ISRC-first (exact, via `search_by_isrc`) with a
+  title/artist search fallback, and each track records `spotify_match`
+  (`"isrc"` | `"search"`) so a consumer can tell a trustworthy exact match
+  from a best-effort search hit. A run summary logs the `isrc`/`search`/`none`
+  counts. Strictly optional: a silent no-op without credentials or when
+  `enrichment_enabled` (env `TRACKLISTIFY_ENRICHMENT_ENABLED`, default `true`)
+  is off. Best-effort — enrichment never fails a run.
+
+### Changed
+
+- **`Track.metadata` platform links moved under a nested `links` object.**
+  `tracklist.json` is the public surface, so this is a consumer-visible
+  change. The flat `shazam_url`, `spotify_search_url`, and
+  `deezer_search_url` keys are now `links.shazam`, `links.spotify_search`,
+  and `links.deezer_search` respectively. `links.spotify` (canonical, set by
+  the new enrichment hook) is distinct from `links.spotify_search`
+  (Shazam-supplied search URL), so a consumer can tell a resolved track link
+  from a search. `apple_music_id` stays flat (an id, not a URL). A track with
+  no link omits `links` entirely.
+
 ## [0.9.1] - 2026-08-03
 
 ### Fixed

--- a/scripts/generate_env_example.py
+++ b/scripts/generate_env_example.py
@@ -115,6 +115,12 @@ FIELD_SECTIONS: list[tuple[str, list[str]]] = [
             "download_cache_enabled",
         ],
     ),
+    (
+        "Metadata enrichment",
+        [
+            "enrichment_enabled",
+        ],
+    ),
 ]
 
 # Inline annotations (units, bounds) that aren't derivable from the dataclass.
@@ -137,6 +143,7 @@ INLINE_COMMENTS: dict[str, str] = {
     "download_quality": "kbps",
     "download_format": "mp3 | flac | ...",
     "shazam_proxy": "e.g. http://127.0.0.1:8080",
+    "enrichment_enabled": "resolve Spotify links post-dedup (no-op w/o creds)",
 }
 
 # Fields rendered as commented-out (optional / not always set).
@@ -155,8 +162,10 @@ CREDENTIALS_BLOCK = """\
 # TRACKLISTIFY_ACR_ACCESS_SECRET=
 # TRACKLISTIFY_ACR_HOST=identify-eu-west-1.acrcloud.com
 #
-# Spotify credentials: currently consumed only by the UNWIRED Spotify
-# downloader/exporter (see docs/BACKLOG.md); not needed for normal runs.
+# Spotify credentials: consumed by the metadata-enrichment hook (resolves a
+# canonical Spotify track link per identified track via client-credentials
+# auth; gated by ENRICHMENT_ENABLED). The downloader/exporter is still
+# unwired (see docs/BACKLOG.md). Not needed for normal identification runs.
 # TRACKLISTIFY_SPOTIFY_CLIENT_ID=
 # TRACKLISTIFY_SPOTIFY_CLIENT_SECRET=
 # TRACKLISTIFY_SPOTIFY_COOKIES=~/.mozilla/firefox/profile/cookies.sqlite

--- a/src/tracklistify/config/base.py
+++ b/src/tracklistify/config/base.py
@@ -231,6 +231,11 @@ class TrackIdentificationConfig(BaseConfig):
     spotify_max_rpm: int = field(default=120)
     spotify_max_concurrent: int = field(default=20)
 
+    # Metadata enrichment: after dedup, resolve a canonical Spotify track link
+    # per unique track (ISRC-first, title/artist fallback). A silent no-op
+    # when Spotify credentials are absent, so ``true`` is a safe default.
+    enrichment_enabled: bool = field(default=True)
+
     # Output formats
     output_format: str = field(default="json")
 

--- a/src/tracklistify/providers/factory.py
+++ b/src/tracklistify/providers/factory.py
@@ -3,9 +3,13 @@
 # Standard library imports
 import os
 import threading
+from typing import TYPE_CHECKING, Optional
 
 # Local imports
 from tracklistify.core.exceptions import ConfigError
+
+if TYPE_CHECKING:
+    from tracklistify.providers.spotify import SpotifyProvider
 
 _provider_factory = None
 _provider_lock = threading.Lock()
@@ -102,6 +106,42 @@ class ProviderFactory:
                 )
             self.providers[provider_name] = provider
             return provider
+
+    # Cache key for the enrichment-only Spotify provider. Distinct from any
+    # identification provider name (KNOWN_PROVIDERS) so it cannot collide, and
+    # leading underscore keeps it out of the identification name space.
+    _SPOTIFY_ENRICHMENT_KEY = "_spotify_enrichment"
+
+    def get_spotify_provider(self) -> "Optional[SpotifyProvider]":
+        """Return a configured Spotify enrichment provider, or None.
+
+        Reads ``TRACKLISTIFY_SPOTIFY_CLIENT_ID`` and
+        ``TRACKLISTIFY_SPOTIFY_CLIENT_SECRET`` from the environment, following
+        the ACRCloud env-only pattern — secrets are deliberately NOT on the
+        config dataclass (they would leak through ``repr()`` and validation
+        error messages).
+
+        Unlike ``get_identification_provider`` for ACRCloud, missing
+        credentials return ``None`` rather than raising ``ConfigError``:
+        identification *requires* its provider, enrichment does not. Absent
+        creds are a skip, not an error. The instance is cached under a
+        non-colliding key so ``close_all()`` closes its aiohttp session; no
+        new lifecycle code.
+        """
+        cached = self.providers.get(self._SPOTIFY_ENRICHMENT_KEY)
+        if cached is not None:
+            return cached
+
+        client_id = os.getenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID")
+        client_secret = os.getenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET")
+        if not client_id or not client_secret:
+            return None
+
+        from tracklistify.providers.spotify import SpotifyProvider
+
+        provider = SpotifyProvider(client_id=client_id, client_secret=client_secret)
+        self.providers[self._SPOTIFY_ENRICHMENT_KEY] = provider
+        return provider
 
     async def close_all(self) -> None:
         """Close all providers."""

--- a/src/tracklistify/providers/spotify.py
+++ b/src/tracklistify/providers/spotify.py
@@ -197,6 +197,54 @@ class SpotifyProvider(MetadataProvider):
             "artists": [a["name"] for a in top["artists"]],
             "album": top["album"]["name"],
             "release_date": top["album"]["release_date"],
+            # Optional fields — use ``.get`` (not bare subscripts) so a
+            # response missing them degrades to empty/None rather than raising.
+            # The enrichment hook builds a canonical track URL from
+            # ``external_urls["spotify"]`` when present.
+            "external_urls": top.get("external_urls") or {},
+            "isrc": (top.get("external_ids") or {}).get("isrc"),
+        }
+
+    async def search_by_isrc(self, isrc: str) -> Dict:
+        """Look up a track by its exact ISRC.
+
+        An ISRC lookup is exact, not fuzzy — the whole point of preferring it
+        over ``search_track`` for enrichment. Returns the same dict shape as
+        ``search_track`` (so a caller handles one shape), or ``{}`` when there
+        are no items.
+
+        Args:
+            isrc: International Standard Recording Code (e.g. ``USABC1234567``).
+
+        Error posture is identical to ``search_track``: re-raise
+        ``RateLimitError`` and ``AuthenticationError`` unchanged (callers
+        honor retry-after timing and 401-driven token refresh), wrap
+        everything else in ``ProviderError``.
+        """
+        try:
+            response = await self._api_request(
+                "GET",
+                "search",
+                params={"q": f"isrc:{isrc}", "type": "track", "limit": 1},
+            )
+        except (RateLimitError, AuthenticationError):
+            raise
+        except Exception as e:
+            raise ProviderError(f"Error searching by ISRC: {e}") from e
+
+        items = response.get("tracks", {}).get("items", [])
+        if not items:
+            return {}
+
+        top = items[0]
+        return {
+            "spotify_id": top["id"],
+            "name": top["name"],
+            "artists": [a["name"] for a in top["artists"]],
+            "album": top["album"]["name"],
+            "release_date": top["album"]["release_date"],
+            "external_urls": top.get("external_urls") or {},
+            "isrc": (top.get("external_ids") or {}).get("isrc"),
         }
 
     async def get_track_details(self, track_id: str) -> Dict:

--- a/src/tracklistify/utils/identification.py
+++ b/src/tracklistify/utils/identification.py
@@ -104,6 +104,21 @@ def _extra_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         else []
     )
 
+    # Per-platform links nest under a ``links`` object (spec unit E / unknown
+    # U4): ``links.spotify`` is canonical-only (set by the enrichment hook),
+    # while Shazam-supplied *search* URLs keep distinct ``spotify_search`` /
+    # ``deezer_search`` keys so a consumer can tell a resolved track link from
+    # a search. ``apple_music_id`` stays flat — it is an id, not a URL.
+    links = {
+        "shazam": metadata.get("shazam_url"),
+        # Platform search links Shazam ships with the match, converted to
+        # clickable https by the provider. Named ``*_search`` because they
+        # are searches, not canonical track URLs — see the provider.
+        "spotify_search": metadata.get("spotify_search_url"),
+        "deezer_search": metadata.get("deezer_search_url"),
+    }
+    links = {k: v for k, v in links.items() if v}
+
     extras = {
         "isrc": isrc,
         "album": metadata.get("album"),
@@ -113,12 +128,7 @@ def _extra_metadata(metadata: Dict[str, Any]) -> Dict[str, Any]:
         "shazam_id": metadata.get("shazam_id"),
         "apple_music_id": metadata.get("apple_music_id"),
         "artwork_url": metadata.get("artwork_url"),
-        "shazam_url": metadata.get("shazam_url"),
-        # Platform search links Shazam ships with the match, converted to
-        # clickable https by the provider. Named ``*_search_url`` because
-        # they are searches, not canonical track URLs — see the provider.
-        "spotify_search_url": metadata.get("spotify_search_url"),
-        "deezer_search_url": metadata.get("deezer_search_url"),
+        "links": links or None,
     }
     return {k: v for k, v in extras.items() if v}
 

--- a/src/tracklistify/utils/identification.py
+++ b/src/tracklistify/utils/identification.py
@@ -374,12 +374,10 @@ class IdentificationManager:
                 if track.metadata.get("links", {}).get("spotify"):
                     continue
 
-                match = await self._enrich_one(
-                    provider, limiter, track, counts, disabled=[False]
-                )
-                # AuthenticationError disables enrichment for the rest of the
-                # run; ``_enrich_one`` flips ``disabled`` in place via the
-                # shared flag below.
+                match = await self._enrich_one(provider, limiter, track, counts)
+                # AuthenticationError/RateLimitError halt enrichment for the
+                # rest of the run — ``_enrich_one`` signals that by returning
+                # the "disabled" sentinel.
                 if match == "disabled":
                     break
 
@@ -397,14 +395,13 @@ class IdentificationManager:
         limiter,
         track: Track,
         counts: Dict[str, int],
-        disabled: List[bool],
     ) -> str:
         """Enrich a single track; return the match kind or sentinel.
 
         Returns ``"isrc"`` / ``"search"`` / ``"none"`` for a processed track,
-        or ``"disabled"`` when an AuthenticationError has halted enrichment for
-        the remainder of the run (the shared ``disabled`` flag is how the
-        caller learns to break).
+        or ``"disabled"`` when an AuthenticationError or RateLimitError has
+        halted enrichment for the remainder of the run — the caller breaks its
+        loop on that sentinel.
 
         Acquire/release pairing is verbatim from the identification loop
         (identification.py:375-407): every ``acquire`` is matched by a
@@ -435,7 +432,6 @@ class IdentificationManager:
                 logger.warning(
                     "Spotify enrichment disabled for this run: authentication failed"
                 )
-                disabled[0] = True
                 limiter.record_result("spotify", success=False)
                 return "disabled"
             except RateLimitError:

--- a/src/tracklistify/utils/identification.py
+++ b/src/tracklistify/utils/identification.py
@@ -15,6 +15,7 @@ from tracklistify.config.factory import get_config
 
 # Local/package imports
 from tracklistify.core.track import Track, TrackMatcher
+from tracklistify.providers.base import AuthenticationError, RateLimitError
 from tracklistify.providers.factory import create_provider_factory
 from .constants import DEFAULT_PROGRESS_BAR_WIDTH, TERMINAL_LINE_WIDTH
 from .logger import get_logger
@@ -322,6 +323,158 @@ class IdentificationManager:
             logger.error(f"Failed to create track from provider response: {e}")
             return None
 
+    async def _enrich_tracks(self, unique_tracks: List[Track]) -> None:
+        """Resolve a canonical Spotify track link per unique track (spec unit D).
+
+        ISRC-first (exact lookup via ``search_by_isrc``), title/artist search
+        fallback (``search_track``). Writes ``metadata["links"]["spotify"]``,
+        ``metadata["spotify_id"]`` and ``metadata["spotify_match"]`` ("isrc" |
+        "search") on a hit. Each run logs a summary count of isrc / search /
+        none — the instrumentation for backlog unknowns U1/U2/U3.
+
+        Post-dedup by design. Sequential, not gather — the volume is ~22 and
+        concurrency buys nothing worth the added failure modes.
+
+        Best-effort (R5): enrichment never fails a run. Error posture —
+        ``AuthenticationError`` → warn once, disable for the rest of the run;
+        ``RateLimitError`` → warn, stop, return enriched-so-far; any other
+        ``Exception`` → debug log, continue to the next track;
+        ``asyncio.CancelledError`` → re-raise, never swallowed.
+
+        Structured so the per-source logic (resolve provider → look up one
+        track → write into ``metadata["links"]``) is separable from the loop
+        scaffolding (gating, limiter pairing, error posture, summary). A
+        MusicBrainz source (backlog U5) slots in without touching the
+        scaffolding — do NOT build an ABC/registry for one implementation.
+        """
+        if not unique_tracks:
+            return
+        if not getattr(self.config, "enrichment_enabled", True):
+            return
+
+        # ``getattr`` fallback: a factory that doesn't supply a Spotify
+        # enrichment provider (e.g. an identification-only stub) degrades to a
+        # no-op, consistent with the no-op-without-credentials posture.
+        get_spotify = getattr(self.provider_factory, "get_spotify_provider", None)
+        provider = get_spotify() if get_spotify is not None else None
+        if provider is None:
+            # No credentials — a skip, not an error. Never touch the limiter.
+            logger.debug("Spotify enrichment skipped: no credentials configured")
+            return
+
+        limiter = get_global_rate_limiter()
+        counts = {"isrc": 0, "search": 0, "none": 0}
+
+        # ``async with provider:`` ensures the aiohttp session is closed even
+        # on an early return. ``close()`` is re-entrant, so the later
+        # ``close_all()`` closing it again is safe (providers/base.py:113-119).
+        async with provider:
+            for track in unique_tracks:
+                # Idempotence: skip a track already carrying a canonical link.
+                if track.metadata.get("links", {}).get("spotify"):
+                    continue
+
+                match = await self._enrich_one(
+                    provider, limiter, track, counts, disabled=[False]
+                )
+                # AuthenticationError disables enrichment for the rest of the
+                # run; ``_enrich_one`` flips ``disabled`` in place via the
+                # shared flag below.
+                if match == "disabled":
+                    break
+
+        enriched = counts["isrc"] + counts["search"]
+        if enriched:
+            logger.info(
+                f"Spotify enrichment: {enriched} links resolved "
+                f"(isrc={counts['isrc']}, search={counts['search']}, "
+                f"none={counts['none']})"
+            )
+
+    async def _enrich_one(
+        self,
+        provider,
+        limiter,
+        track: Track,
+        counts: Dict[str, int],
+        disabled: List[bool],
+    ) -> str:
+        """Enrich a single track; return the match kind or sentinel.
+
+        Returns ``"isrc"`` / ``"search"`` / ``"none"`` for a processed track,
+        or ``"disabled"`` when an AuthenticationError has halted enrichment for
+        the remainder of the run (the shared ``disabled`` flag is how the
+        caller learns to break).
+
+        Acquire/release pairing is verbatim from the identification loop
+        (identification.py:375-407): every ``acquire`` is matched by a
+        ``release`` in ``finally``, and every outcome is reported via
+        ``record_result`` or the circuit breaker never learns (invariant I6).
+        """
+        isrc = track.metadata.get("isrc")
+
+        acquired = False
+        try:
+            acquired = await limiter.acquire("spotify")
+            if not acquired:
+                logger.debug("Spotify enrichment: rate limiter rejected request")
+                counts["none"] += 1
+                return "none"
+
+            try:
+                if isrc:
+                    result = await provider.search_by_isrc(isrc)
+                    match_kind = "isrc"
+                else:
+                    result = await provider.search_track(
+                        title=track.song_name, artist=track.artist
+                    )
+                    match_kind = "search"
+            except AuthenticationError:
+                # Warn once, disable enrichment for the remainder of the run.
+                logger.warning(
+                    "Spotify enrichment disabled for this run: authentication failed"
+                )
+                disabled[0] = True
+                limiter.record_result("spotify", success=False)
+                return "disabled"
+            except RateLimitError:
+                # Warn, stop enriching, return tracks enriched so far.
+                logger.warning(
+                    "Spotify enrichment stopped: rate limit hit; tracks "
+                    "enriched so far are kept"
+                )
+                limiter.record_result("spotify", success=False)
+                return "disabled"
+            except asyncio.CancelledError:
+                raise
+            except Exception as e:
+                # Debug log, continue to the next track.
+                logger.debug(f"Spotify enrichment failed for one track: {e}")
+                limiter.record_result("spotify", success=False)
+                counts["none"] += 1
+                return "none"
+
+            if not result:
+                counts["none"] += 1
+                limiter.record_result("spotify", success=True)
+                return "none"
+
+            # On a hit, prefer external_urls["spotify"] over the constructed URL.
+            external = result.get("external_urls") or {}
+            link = external.get("spotify") or (
+                f"https://open.spotify.com/track/{result['spotify_id']}"
+            )
+            track.metadata.setdefault("links", {})["spotify"] = link
+            track.metadata["spotify_id"] = result["spotify_id"]
+            track.metadata["spotify_match"] = match_kind
+            counts[match_kind] += 1
+            limiter.record_result("spotify", success=True)
+            return match_kind
+        finally:
+            if acquired:
+                limiter.release("spotify")
+
     async def identify_tracks(self, audio_segments):
         provider_names = self._provider_chain()
 
@@ -428,6 +581,13 @@ class IdentificationManager:
                 f"{len(identified_tracks)} total matches"
             )
         )
+
+        # Enrich unique tracks with canonical Spotify links (post-dedup by
+        # design: ~22 unique tracks, not ~216 raw detections — a 10x cut in
+        # API calls, and keeps the rate limiter out of the hot path). Strictly
+        # optional: a silent no-op without credentials or when disabled. Best-
+        # effort (R5): every error path leaves the identified tracks intact.
+        await self._enrich_tracks(unique_tracks)
 
         # A broken pipeline and an unidentifiable set look identical from
         # here: both end with zero matches. The per-segment no-match line

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -585,3 +585,17 @@ def test_post_init_runs_each_step_once(monkeypatch):
     cfg_mod.TrackIdentificationConfig()
 
     assert counts == {"load": 1, "setup": 1, "validate": 1}
+
+
+def test_enrichment_enabled_default_and_override(monkeypatch):
+    """enrichment_enabled defaults to True (a no-op without creds, so on is
+    safe) and is overridable via TRACKLISTIFY_ENRICHMENT_ENABLED."""
+    for key in [k for k in os.environ if k.startswith("TRACKLISTIFY_")]:
+        monkeypatch.delenv(key, raising=False)
+
+    clear_config()
+    assert get_config().enrichment_enabled is True
+
+    monkeypatch.setenv("TRACKLISTIFY_ENRICHMENT_ENABLED", "false")
+    clear_config()
+    assert get_config().enrichment_enabled is False

--- a/tests/test_identification_utils.py
+++ b/tests/test_identification_utils.py
@@ -278,9 +278,11 @@ class TestExtraMetadata:
             "shazam_id": "k1",
             "apple_music_id": "am-999",
             "artwork_url": "https://img/hq.jpg",
-            "shazam_url": "https://shazam/1",
-            "spotify_search_url": "https://open.spotify.com/search/Berghain",
-            "deezer_search_url": "https://www.deezer.com/search/Berghain",
+            "links": {
+                "shazam": "https://shazam/1",
+                "spotify_search": "https://open.spotify.com/search/Berghain",
+                "deezer_search": "https://www.deezer.com/search/Berghain",
+            },
         }
 
     def test_empty_values_are_dropped_not_stored_as_none(self):
@@ -301,6 +303,35 @@ class TestExtraMetadata:
         assert _extra_metadata({"genres": "Techno"}) == {}
         assert _extra_metadata({"genres": [None, {"no_name": 1}]}) == {}
         assert _extra_metadata(None) == {}
+
+    def test_links_omitted_when_no_link_present(self):
+        """A track with no platform link has no ``links`` key at all — the
+        existing falsy-drop extends to an empty links object (spec E / test 17)."""
+        from tracklistify.utils.identification import _extra_metadata
+
+        # isrc/album/etc. present but none of the *_url fields → no links key.
+        extras = _extra_metadata(
+            {"title": "X", "external_ids": {"isrc": "USABC1234567"}, "album": "A"}
+        )
+        assert "links" not in extras
+
+    def test_save_json_round_trips_nested_links(self):
+        """_save_json emits metadata verbatim (default=str); a nested links
+        object must survive a json round-trip (spec E / test 18)."""
+        import json
+
+        from tracklistify.utils.identification import _extra_metadata
+
+        extras = _extra_metadata(
+            {"shazam_url": "https://shazam/1", "spotify_search_url": "https://sp/s"}
+        )
+        assert extras["links"] == {
+            "shazam": "https://shazam/1",
+            "spotify_search": "https://sp/s",
+        }
+        # _save_json uses json.dumps(..., default=str); links is plain str→str.
+        round_tripped = json.loads(json.dumps(extras, default=str))
+        assert round_tripped["links"] == extras["links"]
 
     def test_track_from_info_attaches_metadata(self):
         """The extras reach Track.metadata through the real build path."""

--- a/tests/test_providers_spotify.py
+++ b/tests/test_providers_spotify.py
@@ -233,3 +233,163 @@ async def test_add_tracks_propagates_rate_limit(provider, monkeypatch):
 
     with pytest.raises(RateLimitError):
         await provider.add_tracks_to_playlist("pid", ["tid1", "tid2"])
+
+
+# --- Unit A: search_track returns external_urls + isrc (spec tests 1, 2) ---
+
+
+@pytest.mark.asyncio
+async def test_search_track_surfaces_external_urls_and_isrc(provider, monkeypatch):
+    """search_track returns external_urls and isrc alongside its other keys."""
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        return {
+            "tracks": {
+                "items": [
+                    {
+                        "id": "abc123",
+                        "name": "Song A",
+                        "artists": [{"name": "Artist X"}],
+                        "album": {"name": "Album Z", "release_date": "2024-01-01"},
+                        "external_urls": {
+                            "spotify": "https://open.spotify.com/track/abc123"
+                        },
+                        "external_ids": {"isrc": "USABC1234567"},
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    result = await provider.search_track("Song A", "Artist X")
+
+    assert result["external_urls"] == {
+        "spotify": "https://open.spotify.com/track/abc123"
+    }
+    assert result["isrc"] == "USABC1234567"
+
+
+@pytest.mark.asyncio
+async def test_search_track_tolerates_missing_external_fields(provider, monkeypatch):
+    """A response with neither external_urls nor external_ids must not raise."""
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        return {
+            "tracks": {
+                "items": [
+                    {
+                        "id": "abc123",
+                        "name": "Song A",
+                        "artists": [{"name": "Artist X"}],
+                        "album": {"name": "Album Z", "release_date": "2024-01-01"},
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    result = await provider.search_track("Song A", "Artist X")
+
+    assert result["external_urls"] == {}
+    assert result["isrc"] is None
+
+
+# --- Unit B: search_by_isrc (spec tests 3, 4) ---
+
+
+@pytest.mark.asyncio
+async def test_search_by_isrc_sends_exact_params(provider, monkeypatch):
+    """search_by_isrc sends q=isrc:<isrc>, type=track, limit=1."""
+    captured = {}
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        captured["params"] = kwargs.get("params", {})
+        return {"tracks": {"items": []}}
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    result = await provider.search_by_isrc("USABC1234567")
+
+    assert captured["params"] == {
+        "q": "isrc:USABC1234567",
+        "type": "track",
+        "limit": 1,
+    }
+    assert result == {}
+
+
+@pytest.mark.asyncio
+async def test_search_by_isrc_returns_same_shape_as_search_track(provider, monkeypatch):
+    """search_by_isrc returns the same dict shape as search_track, not raw API."""
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        return {
+            "tracks": {
+                "items": [
+                    {
+                        "id": "abc123",
+                        "name": "Song A",
+                        "artists": [{"name": "Artist X"}],
+                        "album": {"name": "Album Z", "release_date": "2024-01-01"},
+                        "external_urls": {
+                            "spotify": "https://open.spotify.com/track/abc123"
+                        },
+                        "external_ids": {"isrc": "USABC1234567"},
+                    }
+                ]
+            }
+        }
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    result = await provider.search_by_isrc("USABC1234567")
+
+    assert result["spotify_id"] == "abc123"
+    assert result["external_urls"]["spotify"] == (
+        "https://open.spotify.com/track/abc123"
+    )
+    assert result["isrc"] == "USABC1234567"
+
+
+@pytest.mark.asyncio
+async def test_search_by_isrc_re_raises_rate_limit(provider, monkeypatch):
+    """RateLimitError must propagate unchanged, not be wrapped."""
+    from tracklistify.providers.base import RateLimitError
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        raise RateLimitError("Spotify rate limit exceeded. Retry after 30s")
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    with pytest.raises(RateLimitError, match="Retry after 30s"):
+        await provider.search_by_isrc("USABC1234567")
+
+
+@pytest.mark.asyncio
+async def test_search_by_isrc_re_raises_auth_error(provider, monkeypatch):
+    """AuthenticationError must propagate unchanged, not be wrapped."""
+    from tracklistify.providers.base import AuthenticationError
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        raise AuthenticationError("Spotify token expired")
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    with pytest.raises(AuthenticationError, match="token expired"):
+        await provider.search_by_isrc("USABC1234567")
+
+
+@pytest.mark.asyncio
+async def test_search_by_isrc_wraps_generic_error(provider, monkeypatch):
+    """Any non-RateLimit/non-Auth error is wrapped in ProviderError."""
+    from tracklistify.core.exceptions import ProviderError
+
+    async def fake_api_request(self, method, endpoint, **kwargs):
+        raise RuntimeError("boom")
+
+    monkeypatch.setattr(SpotifyProvider, "_api_request", fake_api_request)
+
+    with pytest.raises(ProviderError, match="Error searching by ISRC"):
+        await provider.search_by_isrc("USABC1234567")

--- a/tests/test_spotify_enrichment.py
+++ b/tests/test_spotify_enrichment.py
@@ -1,0 +1,333 @@
+"""Tests for the post-dedup Spotify enrichment hook (spec unit D).
+
+The hook lives on ``IdentificationManager._enrich_tracks`` and is exercised
+directly here — mocking the Spotify provider and the rate limiter, never the
+network. Covers spec tests 7-15.
+"""
+
+import pytest
+
+from tracklistify.config import get_config
+from tracklistify.core.track import Track
+from tracklistify.providers.base import AuthenticationError, RateLimitError
+from tracklistify.utils.identification import IdentificationManager
+
+
+def _track(song_name="Song", artist="Artist", metadata=None):
+    return Track(
+        song_name=song_name,
+        artist=artist,
+        time_in_mix="00:00:10",
+        confidence=90.0,
+        metadata=metadata or {},
+    )
+
+
+class _FakeSpotifyProvider:
+    """Minimal provider exposing the two search methods + async CM."""
+
+    def __init__(self):
+        self.isrc_calls = 0
+        self.search_calls = 0
+        # What the next search_by_isrc / search_track call returns.
+        self.isrc_result = {}
+        self.search_result = {}
+        self.isrc_exc = None
+        self.search_exc = None
+
+    async def __aenter__(self):
+        return self
+
+    async def __aexit__(self, *a):
+        return None
+
+    async def search_by_isrc(self, isrc):
+        self.isrc_calls += 1
+        if self.isrc_exc:
+            raise self.isrc_exc
+        return self.isrc_result
+
+    async def search_track(self, title, artist=None, album=None, duration=None):
+        self.search_calls += 1
+        if self.search_exc:
+            raise self.search_exc
+        return self.search_result
+
+    async def close(self):
+        pass
+
+
+class _CountingLimiter:
+    """Records acquire/release/record_result so tests assert pairing."""
+
+    def __init__(self, acquire_ok=True):
+        self.acquire_ok = acquire_ok
+        self.acquires = 0
+        self.releases = 0
+        self.results = []
+
+    async def acquire(self, provider):
+        self.acquires += 1
+        return self.acquire_ok
+
+    def release(self, provider):
+        self.releases += 1
+
+    def record_result(self, provider, success):
+        self.results.append(success)
+
+
+class _EnrichFactory:
+    """Factory stub that returns a fixed Spotify provider (or None)."""
+
+    def __init__(self, provider):
+        self._spotify = provider
+
+    def get_spotify_provider(self):
+        return self._spotify
+
+
+def _mgr(provider, limiter, monkeypatch):
+    monkeypatch.setattr(
+        "tracklistify.utils.identification.get_global_rate_limiter", lambda: limiter
+    )
+    config = get_config(force_refresh=True)
+    config.enrichment_enabled = True
+    return IdentificationManager(
+        config=config, provider_factory=_EnrichFactory(provider)
+    )
+
+
+@pytest.mark.asyncio
+async def test_isrc_path_preferred_when_isrc_present(monkeypatch):
+    """metadata['isrc'] present → search_by_isrc called, search_track not."""
+    provider = _FakeSpotifyProvider()
+    provider.isrc_result = {
+        "spotify_id": "abc",
+        "external_urls": {"spotify": "https://open.spotify.com/track/abc"},
+        "isrc": "USABC1234567",
+    }
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track(metadata={"isrc": "USABC1234567"})
+
+    await mgr._enrich_tracks([track])
+
+    assert provider.isrc_calls == 1
+    assert provider.search_calls == 0
+    assert track.metadata["spotify_match"] == "isrc"
+
+
+@pytest.mark.asyncio
+async def test_search_fallback_when_no_isrc(monkeypatch):
+    """No ISRC → search_track used with raw song_name + artist."""
+    provider = _FakeSpotifyProvider()
+    provider.search_result = {"spotify_id": "def", "external_urls": {}}
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track(song_name="Raw Title", artist="Raw Artist")
+
+    await mgr._enrich_tracks([track])
+
+    assert provider.isrc_calls == 0
+    assert provider.search_calls == 1
+    assert track.metadata["spotify_match"] == "search"
+
+
+@pytest.mark.asyncio
+async def test_external_urls_wins_over_constructed_url(monkeypatch):
+    """external_urls['spotify'] preferred over the constructed track URL."""
+    provider = _FakeSpotifyProvider()
+    provider.search_result = {
+        "spotify_id": "abc",
+        "external_urls": {"spotify": "https://open.spotify.com/track/abc"},
+    }
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track()
+
+    await mgr._enrich_tracks([track])
+
+    assert track.metadata["links"]["spotify"] == ("https://open.spotify.com/track/abc")
+
+
+@pytest.mark.asyncio
+async def test_constructed_url_when_no_external_urls(monkeypatch):
+    """No external_urls → URL constructed from spotify_id."""
+    provider = _FakeSpotifyProvider()
+    provider.search_result = {"spotify_id": "xyz", "external_urls": {}}
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track()
+
+    await mgr._enrich_tracks([track])
+
+    assert track.metadata["links"]["spotify"] == ("https://open.spotify.com/track/xyz")
+    assert track.metadata["spotify_id"] == "xyz"
+
+
+@pytest.mark.asyncio
+async def test_track_with_existing_spotify_link_skipped(monkeypatch):
+    """A track already carrying links['spotify'] is left untouched."""
+    provider = _FakeSpotifyProvider()
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track(
+        metadata={"links": {"spotify": "https://open.spotify.com/track/old"}}
+    )
+
+    await mgr._enrich_tracks([track])
+
+    assert provider.isrc_calls == 0
+    assert provider.search_calls == 0
+    # Limiter never touched for a skipped track.
+    assert limiter.acquires == 0
+
+
+@pytest.mark.asyncio
+async def test_no_credentials_is_noop_and_never_touches_limiter(monkeypatch):
+    """provider is None → no-op; rate limiter never acquired."""
+    limiter = _CountingLimiter()
+    config = get_config(force_refresh=True)
+    config.enrichment_enabled = True
+    mgr = IdentificationManager(config=config, provider_factory=_EnrichFactory(None))
+    monkeypatch.setattr(
+        "tracklistify.utils.identification.get_global_rate_limiter", lambda: limiter
+    )
+    track = _track()
+
+    await mgr._enrich_tracks([track])
+
+    assert limiter.acquires == 0
+    assert "spotify_match" not in track.metadata
+
+
+@pytest.mark.asyncio
+async def test_enrichment_disabled_is_noop(monkeypatch):
+    """enrichment_enabled = false → no-op."""
+    provider = _FakeSpotifyProvider()
+    limiter = _CountingLimiter()
+    config = get_config(force_refresh=True)
+    config.enrichment_enabled = False
+    mgr = IdentificationManager(
+        config=config, provider_factory=_EnrichFactory(provider)
+    )
+    monkeypatch.setattr(
+        "tracklistify.utils.identification.get_global_rate_limiter", lambda: limiter
+    )
+
+    await mgr._enrich_tracks([_track()])
+
+    assert limiter.acquires == 0
+    assert provider.isrc_calls == 0
+
+
+@pytest.mark.asyncio
+async def test_authentication_error_disables_for_run_and_keeps_tracks(monkeypatch):
+    """R5: AuthenticationError → warn, disable for run, tracks intact."""
+    provider = _FakeSpotifyProvider()
+    provider.search_exc = AuthenticationError("bad creds")
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    tracks = [_track(), _track(), _track()]
+
+    await mgr._enrich_tracks(tracks)
+
+    # Only the first track triggers the provider call; the rest are skipped.
+    assert provider.search_calls == 1
+    # No track gained a spotify link, all three survive unchanged.
+    for t in tracks:
+        assert "spotify_match" not in t.metadata
+        assert t.metadata.get("links", {}).get("spotify") is None
+
+
+@pytest.mark.asyncio
+async def test_rate_limit_stops_enriching_and_keeps_so_far(monkeypatch):
+    """R5: RateLimitError → stop, return tracks enriched so far."""
+    provider = _FakeSpotifyProvider()
+    provider.search_exc = RateLimitError("slow down")
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+
+    await mgr._enrich_tracks([_track(), _track()])
+
+    assert provider.search_calls == 1
+
+
+@pytest.mark.asyncio
+async def test_generic_exception_continues_to_next_track(monkeypatch):
+    """R5: a generic Exception on one track continues to the next."""
+    provider = _FakeSpotifyProvider()
+    provider.search_exc = RuntimeError("transient")
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+
+    await mgr._enrich_tracks([_track(), _track()])
+
+    # Both tracks attempted (error does not halt the loop).
+    assert provider.search_calls == 2
+
+
+@pytest.mark.asyncio
+async def test_limiter_released_on_every_path(monkeypatch):
+    """R6: acquire/release counts match across normal + exception paths."""
+    provider = _FakeSpotifyProvider()
+    provider.search_exc = RuntimeError("transient")
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+
+    await mgr._enrich_tracks([_track(), _track(), _track()])
+
+    assert limiter.acquires == 3
+    assert limiter.releases == 3
+
+
+@pytest.mark.asyncio
+async def test_limiter_released_on_no_hit_path(monkeypatch):
+    """R6: a no-hit track still releases the limiter."""
+    provider = _FakeSpotifyProvider()  # empty results → no hit
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+
+    await mgr._enrich_tracks([_track(), _track()])
+
+    assert limiter.acquires == 2
+    assert limiter.releases == 2
+
+
+@pytest.mark.asyncio
+async def test_summary_counts_mixed_run(monkeypatch, caplog):
+    """R7: the run summary reports isrc/search/none counts at INFO."""
+    import logging
+
+    provider = _FakeSpotifyProvider()
+    provider.isrc_result = {"spotify_id": "a", "external_urls": {}}
+    provider.search_result = {"spotify_id": "b", "external_urls": {}}
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    tracks = [
+        _track(metadata={"isrc": "X1"}),  # isrc hit
+        _track(),  # search hit
+    ]
+
+    with caplog.at_level(logging.INFO, logger="tracklistify.utils.identification"):
+        await mgr._enrich_tracks(tracks)
+
+    summary = [r.message for r in caplog.records if "enrichment" in r.message]
+    assert any("isrc=1" in m and "search=1" in m and "none=0" in m for m in summary)
+
+
+@pytest.mark.asyncio
+async def test_no_hit_track_left_untouched(monkeypatch):
+    """A track with no Spotify hit is untouched and counted as none."""
+    provider = _FakeSpotifyProvider()  # empty results
+    limiter = _CountingLimiter()
+    mgr = _mgr(provider, limiter, monkeypatch)
+    track = _track(metadata={"isrc": "NONE"})
+
+    await mgr._enrich_tracks([track])
+
+    assert "spotify_match" not in track.metadata
+    assert "links" not in track.metadata or "spotify" not in track.metadata.get(
+        "links", {}
+    )

--- a/tests/test_spotify_factory.py
+++ b/tests/test_spotify_factory.py
@@ -1,0 +1,66 @@
+"""Tests for ProviderFactory.get_spotify_provider (enrichment accessor)."""
+
+import pytest
+
+from tracklistify.providers.factory import KNOWN_PROVIDERS, ProviderFactory
+
+
+@pytest.fixture
+def factory():
+    return ProviderFactory()
+
+
+def test_get_spotify_provider_none_without_creds(monkeypatch, factory):
+    """No creds → None, never raises (enrichment is optional)."""
+    monkeypatch.delenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID", raising=False)
+    monkeypatch.delenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET", raising=False)
+
+    assert factory.get_spotify_provider() is None
+
+
+def test_get_spotify_provider_none_with_one_cred(monkeypatch, factory):
+    """Only one of the two creds set → still None."""
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID", "cid")
+    monkeypatch.delenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET", raising=False)
+
+    assert factory.get_spotify_provider() is None
+
+
+def test_get_spotify_provider_returns_instance_with_both_creds(monkeypatch, factory):
+    """Both creds set → a SpotifyProvider."""
+    from tracklistify.providers.spotify import SpotifyProvider
+
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET", "csec")
+
+    provider = factory.get_spotify_provider()
+    assert isinstance(provider, SpotifyProvider)
+    assert provider.client_id == "cid"
+    assert provider.client_secret == "csec"
+
+
+def test_get_spotify_provider_is_cached(monkeypatch, factory):
+    """The instance is memoized — a second call returns the same object."""
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET", "csec")
+
+    first = factory.get_spotify_provider()
+    second = factory.get_spotify_provider()
+    assert first is second
+
+
+def test_spotify_not_in_known_providers():
+    """Spotify is NOT an identification provider — it has no identify_track."""
+    assert "spotify" not in KNOWN_PROVIDERS
+
+
+def test_spotify_cache_key_does_not_collide_with_identification(monkeypatch, factory):
+    """The enrichment provider sits under a non-colliding key, so it never
+    shadows an identification provider lookup."""
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_ID", "cid")
+    monkeypatch.setenv("TRACKLISTIFY_SPOTIFY_CLIENT_SECRET", "csec")
+
+    factory.get_spotify_provider()
+    # The enrichment key is not a valid identification provider name.
+    for key in factory.providers:
+        assert key not in KNOWN_PROVIDERS


### PR DESCRIPTION
## Summary

Resolves the **P2 "Spotify enrichment is built but unreachable"** backlog item and decides the **P3 `metadata` link-schema** question (unknown U4 → nested `metadata.links`).

- **Canonical Spotify track links** via a post-dedup enrichment hook. ISRC-first (exact `search_by_isrc`), title/artist search fallback. Each matched track records `spotify_match: "isrc" | "search"` so a consumer can tell a trustworthy exact match from a best-effort search hit — the instrumentation for backlog unknown U3 (wrong-match rate becomes auditable from real output instead of guessed).
- **`metadata.links` schema.** Flat `shazam_url` / `spotify_search_url` / `deezer_search_url` → nested `links.{shazam,spotify_search,deezer_search}`. `links.spotify` is canonical-only (set by the hook); the Shazam-supplied search URLs keep distinct `*_search` keys so a consumer can tell a resolved track link from a search. `apple_music_id` stays flat (an id, not a URL). `tracklist.json` is the public surface → consumer-visible change, called out in the changelog.

Strictly optional: a silent no-op without Spotify credentials or when `enrichment_enabled` (default `true`) is off. Best-effort — enrichment never fails a run (R5). Rate-limiter acquire/release paired on every path incl. exceptions (R6).

Spec: \`docs/dev/2026-08-02-spotify-link-enrichment-spec.md\` (local-only, not in the released repo).

## Units

- **A** — `search_track` returns `external_urls` + `isrc`.
- **B** — new exact `search_by_isrc`.
- **C** — `get_spotify_provider()` factory accessor (env-only creds, `None` when absent, `KNOWN_PROVIDERS` untouched).
- **D** — post-dedup enrichment hook (`_enrich_tracks` / `_enrich_one`).
- **E** — `metadata.links` schema migration in `_extra_metadata`.
- config `enrichment_enabled` + `.env.example` drift.

## Verification

- \`uv run python -m pytest -q\` → **570 passed** (540 baseline + 30 new), 0 regressions.
- \`uv run ruff check\` / \`ruff format --check\` / \`generate_env_example.py --check\` → all exit 0.
- \`KNOWN_PROVIDERS\` unchanged; no Spotify credential on any config dataclass.
- Survived an adversarial review pass (CONFIRMED); one non-blocking finding (dead \`disabled\` param) fixed.

### One caveat (criterion 4, DEFERRED)

Live end-to-end enrichment is blocked behind an **external** Spotify gate, not a code defect: as of late 2024, the Web API requires a Premium-backed developer app for client-credentials access. Token fetch verifies (valid creds), but Search returns 403 until the app is in Development Mode / has a quota extension. Until then a real run exercises the R5 generic-exception path (debug-log, continue, run succeeds), which is unit- and live-tested. The MusicBrainz source (separate PR, stacked on this one) is the keyless alternative that works today.

## Not in scope

- Playlist export / authorization-code + PKCE (U9 — separate feature project).
- Adding `spotify` to `KNOWN_PROVIDERS` (it has no `identify_track`; would break invariant I3).
- Markdown/M3U rendering of metadata.