### PR TITLE
fix: Windows path, encoding and test-portability failures (#85)

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -50,6 +50,36 @@ Release dates are in YYYY-MM-DD format.
   the win32 branch executes identically on every host, and asserts the
   actual decision table: `GetLastError` 87 → dead, 5 (ACCESS_DENIED)
   → alive. Caught by @deroverda.
+- **`file://` URIs were never percent-decoded (#85).** `validate_input`
+  built the local path with `Path(urlparse(s).path)`, but `urlparse`
+  returns a URL path, not a filesystem path: a space stays `%20`, so any
+  `file://` URI containing a space or a non-ASCII character resolved to a
+  path that does not exist and validation returned `None`. Not
+  Windows-specific — it failed identically on macOS and Linux, and only
+  escaped notice because the existing tests build URIs from `tmp_path`
+  names, which have no spaces. On Windows it additionally mangled drive
+  letters (`file:///C:/x` → `/C:/x`). Now goes through `url2pathname`.
+  The authority component, previously dropped in silence, is handled too:
+  `file://localhost/p` is accepted as the same file as `file:///p`, and
+  any other host is a Windows UNC path — rebuilt as `\\host\share`
+  there, rejected elsewhere rather than reinterpreted, since dropping it
+  resolved `file://evil/etc/passwd` to the local `/etc/passwd`.
+- **Text files were read and written with the locale encoding (#85).**
+  Bare `open()` uses `locale.getpreferredencoding()` — cp1252 on a default
+  Windows install. `core/track.py` has 51 non-ASCII lines (em-dashes,
+  `ROSALÍA`, `Björk` in the artist-matching docstrings) and cp1252 cannot
+  decode the first one, which is what broke the source-scanning tests on
+  Windows. 61 test call sites and four production sites are now explicit:
+  `core/run.py` (the `.env.example` → `.env` copy) and
+  `providers/beatport.py` (the token cache) state `encoding="utf-8"`;
+  `config/validation.py` opens paths only to probe readability, decodes
+  nothing, and now uses binary mode. No behavior change on POSIX.
+- **Two tests asserted POSIX-only facts on every platform (#85).** The
+  Beatport token cache's `st_mode & 0o777 == 0o600` check is now guarded by
+  `os.name == "posix"` — NTFS has ACLs, not mode bits, and `Path.chmod`
+  only toggles the read-only flag there. The default-output-path assertion
+  compared a string ending in `.tracklistify/output`, which Windows renders
+  with a backslash; it now compares `Path.parts`.
 
 ### Added
 

--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -94,7 +94,7 @@ Release dates are in YYYY-MM-DD format.
 - **Dependency bumps** (#80, #83): `uv_build` `>=0.12.0` → `>=0.12.4`,
   `python-dotenv` 1.2.2 → 1.2.3, `click` 8.4.2 → 8.5.0, `pre-commit` 4.6.1 →
   4.6.2, `ruff` 0.16.1 → 0.16.5, `commitizen` 4.17.0 → 4.18.0, `pylint`
-  4.0.6 → 4.0.7, `mypy` 2.3.0 → 2.3.1.
+  4.0.6 → 4.0.8, `mypy` 2.3.0 → 2.3.1.
 
 ## [0.11.1] - 2026-08-08
 

--- a/src/tracklistify/config/validation.py
+++ b/src/tracklistify/config/validation.py
@@ -268,7 +268,7 @@ class PathRule(ValidationRule):
         if PathRequirement.READABLE in self.requirements:
             try:
                 if path.is_file():
-                    with open(path, "r"):
+                    with open(path, "rb"):
                         pass
             except Exception as e:
                 raise PathValidationError(
@@ -278,7 +278,7 @@ class PathRule(ValidationRule):
         if PathRequirement.WRITABLE in self.requirements:
             try:
                 if path.is_file():
-                    with open(path, "a"):
+                    with open(path, "ab"):
                         pass
                 else:
                     # Create directory if it doesn't exist

--- a/src/tracklistify/core/run.py
+++ b/src/tracklistify/core/run.py
@@ -12,8 +12,8 @@ def setup_environment():
     env_path = get_root() / ".env"
     if not env_path.exists() and (get_root() / ".env.example").exists():
         print("Creating .env from .env.example...")
-        with open(get_root() / ".env.example") as f:
-            with open(env_path, "w") as env:
+        with open(get_root() / ".env.example", encoding="utf-8") as f:
+            with open(env_path, "w", encoding="utf-8") as env:
                 env.write(f.read())
         print("Please edit .env with your credentials")
         sys.exit(1)

--- a/src/tracklistify/providers/beatport.py
+++ b/src/tracklistify/providers/beatport.py
@@ -151,7 +151,7 @@ class BeatportProvider:
         if self._token_path is None:
             return None
         try:
-            data = json.loads(Path(self._token_path).read_text())
+            data = json.loads(Path(self._token_path).read_text(encoding="utf-8"))
         except (OSError, ValueError) as e:
             logger.debug(f"Beatport token cache unreadable ({type(e).__name__}); miss")
             return None
@@ -183,7 +183,7 @@ class BeatportProvider:
         }
         try:
             path.parent.mkdir(parents=True, exist_ok=True)
-            path.write_text(json.dumps(payload))
+            path.write_text(json.dumps(payload), encoding="utf-8")
             path.chmod(0o600)
         except OSError as e:
             logger.debug(f"Could not cache Beatport token: {e}")

--- a/src/tracklistify/utils/validation.py
+++ b/src/tracklistify/utils/validation.py
@@ -3,9 +3,11 @@ Input validation utilities for Tracklistify.
 """
 
 # Standard library imports
+import sys
 from pathlib import Path
 from typing import Iterable, Optional, Tuple
 from urllib.parse import urlparse
+from urllib.request import url2pathname
 
 # Local/package imports
 from .logger import get_logger
@@ -42,7 +44,18 @@ def validate_input(input_path: str) -> Optional[Tuple[str, bool]]:
 
     # file:// URL -> treat as local file
     if parsed.scheme == "file":
-        local = Path(parsed.path).expanduser()
+        # urlparse gives a URL path, not a filesystem path: percent-escapes
+        # are still encoded (a space stays %20) and Windows drive letters
+        # arrive with a leading slash ("/C:/x"). url2pathname decodes and
+        # denormalizes per platform.
+        raw = url2pathname(parsed.path)
+        host = parsed.netloc
+        if host and host.lower() != "localhost":
+            # A remote host is only meaningful as a Windows UNC path.
+            if sys.platform != "win32":
+                return None
+            raw = f"\\\\{host}{raw}"
+        local = Path(raw).expanduser()
         if local.exists() and local.is_file():
             try:
                 return str(local.resolve(strict=True)), True

--- a/tests/test_code_organization.py
+++ b/tests/test_code_organization.py
@@ -19,7 +19,7 @@ class TestModuleLevelImports:
         """core/base.py should import os at module level."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -39,7 +39,7 @@ class TestModuleLevelImports:
         """core/base.py should import shutil at module level."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -59,7 +59,7 @@ class TestModuleLevelImports:
         """core/base.py should import subprocess at module level."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -81,7 +81,7 @@ class TestModuleLevelImports:
         """core/base.py should import mutagen.File at module level."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -102,7 +102,7 @@ class TestModuleLevelImports:
         """cache/index.py should import zlib at module level."""
         file_path = Path("src/tracklistify/cache/index.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -126,7 +126,7 @@ class TestNoRedundantInlineImports:
         """core/base.py should not have inline os import in split_audio."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -147,7 +147,7 @@ class TestNoRedundantInlineImports:
         """core/base.py should not have inline shutil import in cleanup."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -168,7 +168,7 @@ class TestNoRedundantInlineImports:
         """cache/index.py should not have inline zlib import."""
         file_path = Path("src/tracklistify/cache/index.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -526,7 +526,9 @@ def test_env_override_defaults(monkeypatch, tmp_path):
     default_config = TrackIdentificationConfig()
     # Default paths are relative to project_root, so they're absolute
     assert default_config.output_dir.is_absolute()
-    assert str(default_config.output_dir).endswith(".tracklistify/output")
+    # Compare path components, not a string with a baked-in separator --
+    # Windows renders this ".tracklistify\\output" (#85).
+    assert default_config.output_dir.parts[-2:] == (".tracklistify", "output")
 
     # Set environment variables to override defaults
     custom_output = tmp_path / "custom_output"

--- a/tests/test_config_security.py
+++ b/tests/test_config_security.py
@@ -17,7 +17,7 @@ class TestConfigSecurity:
     def test_no_eval_in_codebase(self):
         """Ensure eval() is not used in config module."""
         config_file = Path("src/tracklistify/config/base.py")
-        with open(config_file) as f:
+        with open(config_file, encoding="utf-8") as f:
             lines = f.readlines()
 
         # Check each line for eval() calls (excluding comments)

--- a/tests/test_downloader_errors.py
+++ b/tests/test_downloader_errors.py
@@ -19,7 +19,7 @@ class TestDownloaderConsistency:
         """Test MixcloudDownloader imports DownloadError."""
         mixcloud_file = Path("src/tracklistify/downloaders/mixcloud.py")
 
-        with open(mixcloud_file) as f:
+        with open(mixcloud_file, encoding="utf-8") as f:
             content = f.read()
 
         assert "from tracklistify.core.exceptions import DownloadError" in content, (
@@ -30,7 +30,7 @@ class TestDownloaderConsistency:
         """Test MixcloudDownloader.download has correct return type."""
         mixcloud_file = Path("src/tracklistify/downloaders/mixcloud.py")
 
-        with open(mixcloud_file) as f:
+        with open(mixcloud_file, encoding="utf-8") as f:
             content = f.read()
 
         # Should have return type annotation of str, not Optional[str]
@@ -42,7 +42,7 @@ class TestDownloaderConsistency:
         """Verify download methods don't explicitly return None on error."""
         mixcloud_file = Path("src/tracklistify/downloaders/mixcloud.py")
 
-        with open(mixcloud_file) as f:
+        with open(mixcloud_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check for problematic pattern: catching exception and returning None
@@ -70,7 +70,7 @@ class TestDownloaderConsistency:
         """Test that MixcloudDownloader raises DownloadError in error handlers."""
         mixcloud_file = Path("src/tracklistify/downloaders/mixcloud.py")
 
-        with open(mixcloud_file) as f:
+        with open(mixcloud_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check that DownloadError is raised in the exception handler
@@ -82,7 +82,7 @@ class TestDownloaderConsistency:
         """Test that YtDlpDownloader raises exceptions on failure."""
         ytdlp_file = Path("src/tracklistify/downloaders/ytdlp.py")
 
-        with open(ytdlp_file) as f:
+        with open(ytdlp_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check that it raises rather than returns None

--- a/tests/test_error_handling.py
+++ b/tests/test_error_handling.py
@@ -32,7 +32,7 @@ class TestNoSilentExceptions:
         ]
 
         for py_file in src_path.rglob("*.py"):
-            with open(py_file) as f:
+            with open(py_file, encoding="utf-8") as f:
                 content = f.read()
 
             tree = ast.parse(content)
@@ -59,7 +59,7 @@ class TestNoSilentExceptions:
         """Shazam cooldown exception should use specific exception types."""
         file_path = Path("src/tracklistify/providers/shazam.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should use specific exception types, not bare Exception
@@ -90,7 +90,7 @@ class TestNoSilentExceptions:
         """Cleanup exceptions in core/base.py should be logged."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -116,7 +116,7 @@ class TestExceptionLogging:
         """Shazam should log cooldown config failures."""
         file_path = Path("src/tracklistify/providers/shazam.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should have logging for cooldown failures

--- a/tests/test_exception_consistency.py
+++ b/tests/test_exception_consistency.py
@@ -199,7 +199,7 @@ class TestNoOrphanExceptionDefinitions:
                 continue
 
             try:
-                with open(py_file) as f:
+                with open(py_file, encoding="utf-8") as f:
                     content = f.read()
 
                 for pattern in disallowed_definitions:

--- a/tests/test_input_validation.py
+++ b/tests/test_input_validation.py
@@ -18,7 +18,7 @@ class TestSafeArrayAccess:
         """identification.py should safely access arrays with length checks."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should not have unsafe [0] access on potentially empty lists
@@ -36,7 +36,7 @@ class TestSafeArrayAccess:
         """identification.py should check artists list before accessing."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should have artists_list variable with safe access
@@ -55,7 +55,7 @@ class TestProgressValidation:
         """create_progress_bar should clamp progress to valid range."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should clamp progress value
@@ -93,7 +93,7 @@ class TestMetadataAccess:
         """identification.py should validate music list before access."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should check if music_list is empty

--- a/tests/test_no_debug_code.py
+++ b/tests/test_no_debug_code.py
@@ -18,7 +18,7 @@ class TestNoDebugCode:
         """Ensure no print() statements in core/track.py."""
         track_file = Path("src/tracklistify/core/track.py")
 
-        with open(track_file) as f:
+        with open(track_file, encoding="utf-8") as f:
             content = f.read()
             lines = content.split("\n")
 
@@ -33,7 +33,7 @@ class TestNoDebugCode:
         """Ensure no debug 'some_method' function exists."""
         track_file = Path("src/tracklistify/core/track.py")
 
-        with open(track_file) as f:
+        with open(track_file, encoding="utf-8") as f:
             content = f.read()
 
             if "def some_method(self):" in content:
@@ -46,7 +46,7 @@ class TestNoDebugCode:
         """Ensure no Mock classes in cache/base.py."""
         cache_file = Path("src/tracklistify/cache/base.py")
 
-        with open(cache_file) as f:
+        with open(cache_file, encoding="utf-8") as f:
             content = f.read()
 
             if "class MockConfig" in content:
@@ -58,7 +58,7 @@ class TestNoDebugCode:
         """Ensure no test-specific if conditions in core/track.py."""
         track_file = Path("src/tracklistify/core/track.py")
 
-        with open(track_file) as f:
+        with open(track_file, encoding="utf-8") as f:
             content = f.read()
 
             test_patterns = [
@@ -77,7 +77,7 @@ class TestNoDebugCode:
         """Ensure no hardcoded test data in production."""
         track_file = Path("src/tracklistify/core/track.py")
 
-        with open(track_file) as f:
+        with open(track_file, encoding="utf-8") as f:
             content = f.read()
 
             # Check for obvious test data
@@ -100,7 +100,7 @@ class TestProductionCodeQuality:
         """Ensure cache uses real configuration, not mocks."""
         cache_file = Path("src/tracklistify/cache/base.py")
 
-        with open(cache_file) as f:
+        with open(cache_file, encoding="utf-8") as f:
             content = f.read()
 
             # Should import get_config
@@ -112,7 +112,7 @@ class TestProductionCodeQuality:
         """Ensure identify_tracks doesn't have NotImplementedError."""
         track_file = Path("src/tracklistify/core/track.py")
 
-        with open(track_file) as f:
+        with open(track_file, encoding="utf-8") as f:
             content = f.read()
 
             # Check for NotImplementedError in identify_tracks method

--- a/tests/test_phase6_polish.py
+++ b/tests/test_phase6_polish.py
@@ -66,7 +66,7 @@ class TestConstantsUsage:
         """time_formatter.py should use time constants."""
         file_path = Path("src/tracklistify/utils/time_formatter.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         assert "SECONDS_PER_HOUR" in content, (
@@ -84,7 +84,7 @@ class TestNoCommentedCode:
         """cache/__init__.py should not have commented-out Cache class."""
         file_path = Path("src/tracklistify/cache/__init__.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Should not have large block of commented code
@@ -103,7 +103,7 @@ class TestNoRedundantComments:
         """Files should not have redundant path comments at top."""
         file_path = Path("src/tracklistify/utils/time_formatter.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             first_line = f.readline()
 
         # Should not start with path comment
@@ -139,7 +139,7 @@ class TestDRYRefactoring:
         """DRY helper function _is_platform_url should exist."""
         file_path = Path("src/tracklistify/utils/validation.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         assert "def _is_platform_url" in content, "DRY helper function should exist"
@@ -148,7 +148,7 @@ class TestDRYRefactoring:
         """URL validation functions should use the DRY helper."""
         file_path = Path("src/tracklistify/utils/validation.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check that validators delegate to helper

--- a/tests/test_providers_beatport.py
+++ b/tests/test_providers_beatport.py
@@ -4,6 +4,7 @@ Mocks the aiohttp session; never hits the network.
 """
 
 import json
+import os
 import time
 
 import pytest
@@ -120,7 +121,13 @@ async def test_password_flow_writes_token_cache_0600(tmp_path):
     assert stored["access_token"] == "AT"
     assert stored["refresh_token"] == "RT"
     assert stored["expires_at"] > time.time()
-    assert path.stat().st_mode & 0o777 == 0o600
+
+    # NTFS has ACLs, not POSIX mode bits: CPython's Path.chmod only toggles
+    # the read-only flag there, so st_mode comes back 0o666 no matter what
+    # the source asked for. The 0600 on the token cache is still the point
+    # of the test on the platforms where the bits mean something (#85).
+    if os.name == "posix":
+        assert path.stat().st_mode & 0o777 == 0o600
 
 
 @pytest.mark.asyncio

--- a/tests/test_resource_management.py
+++ b/tests/test_resource_management.py
@@ -89,7 +89,7 @@ class TestProviderCleanup:
         """Provider base should define abstract close method."""
         file_path = Path("src/tracklistify/providers/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -121,7 +121,7 @@ class TestProviderCleanup:
         """__aexit__ should call close() for cleanup."""
         file_path = Path("src/tracklistify/providers/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # __aexit__ should contain "await self.close()"

--- a/tests/test_spotify_encapsulation.py
+++ b/tests/test_spotify_encapsulation.py
@@ -20,7 +20,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyPlaylistExporter doesn't access _session."""
         exporter_file = Path("src/tracklistify/exporters/spotify.py")
 
-        with open(exporter_file) as f:
+        with open(exporter_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check for direct _session access
@@ -34,7 +34,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyPlaylistExporter doesn't access _get_auth_headers."""
         exporter_file = Path("src/tracklistify/exporters/spotify.py")
 
-        with open(exporter_file) as f:
+        with open(exporter_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check for _get_auth_headers access
@@ -48,7 +48,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyPlaylistExporter doesn't access _api_request directly."""
         exporter_file = Path("src/tracklistify/exporters/spotify.py")
 
-        with open(exporter_file) as f:
+        with open(exporter_file, encoding="utf-8") as f:
             content = f.read()
 
         # Check for _api_request access
@@ -62,7 +62,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyProvider has public create_playlist method."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -86,7 +86,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyProvider has public add_tracks_to_playlist method."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -110,7 +110,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyPlaylistExporter calls create_playlist."""
         exporter_file = Path("src/tracklistify/exporters/spotify.py")
 
-        with open(exporter_file) as f:
+        with open(exporter_file, encoding="utf-8") as f:
             content = f.read()
 
         # Should call the public method
@@ -122,7 +122,7 @@ class TestSpotifyEncapsulation:
         """Ensure SpotifyPlaylistExporter calls add_tracks_to_playlist."""
         exporter_file = Path("src/tracklistify/exporters/spotify.py")
 
-        with open(exporter_file) as f:
+        with open(exporter_file, encoding="utf-8") as f:
             content = f.read()
 
         # Should call the public method
@@ -138,7 +138,7 @@ class TestSpotifyProviderPublicAPI:
         """Test create_playlist has correct parameters."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -165,7 +165,7 @@ class TestSpotifyProviderPublicAPI:
         """Test add_tracks_to_playlist has correct parameters."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -195,7 +195,7 @@ class TestSpotifyProviderPublicAPI:
         """Test create_playlist is an async method."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -215,7 +215,7 @@ class TestSpotifyProviderPublicAPI:
         """Test add_tracks_to_playlist is an async method."""
         provider_file = Path("src/tracklistify/providers/spotify.py")
 
-        with open(provider_file) as f:
+        with open(provider_file, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)

--- a/tests/test_time_consistency.py
+++ b/tests/test_time_consistency.py
@@ -21,7 +21,7 @@ class TestTimeHandlingConsistency:
         """Identification manager should use monotonic time for elapsed tracking."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check for elapsed time patterns using time.time()
@@ -42,7 +42,7 @@ class TestTimeHandlingConsistency:
         """
         file_path = Path("src/tracklistify/cache/invalidation.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Verify time.time() is used (correct for persisted timestamps)
@@ -54,7 +54,7 @@ class TestTimeHandlingConsistency:
         """Rate limiter should consistently use monotonic time."""
         file_path = Path("src/tracklistify/utils/rate_limiter.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Rate limiter should NOT use time.time() for elapsed calculations
@@ -76,7 +76,7 @@ class TestTimeHandlingConsistency:
         """Cache base should use time.time() for absolute timestamps."""
         file_path = Path("src/tracklistify/cache/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # "created" and "last_accessed" timestamps should use time.time() (absolute)
@@ -89,7 +89,7 @@ class TestTimeHandlingConsistency:
         """Cache index should use time.time() for absolute timestamps."""
         file_path = Path("src/tracklistify/cache/index.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Timestamps should use time.time() (absolute)
@@ -104,7 +104,7 @@ class TestMonotonicTimeImports:
         """Identification should import time module."""
         file_path = Path("src/tracklistify/utils/identification.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         assert "import time" in content, "identification.py should import time module"

--- a/tests/test_type_hints.py
+++ b/tests/test_type_hints.py
@@ -21,7 +21,7 @@ class TestAnyTypeUsage:
         """Cache index should use typing.Any, not lowercase any."""
         file_path = Path("src/tracklistify/cache/index.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check imports include Any
@@ -39,7 +39,7 @@ class TestAnyTypeUsage:
         """Cache storage should use typing.Any, not lowercase any."""
         file_path = Path("src/tracklistify/cache/storage.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check imports include Any
@@ -70,7 +70,7 @@ class TestReturnTypeAnnotations:
             if not path.exists():
                 continue
 
-            with open(path) as f:
+            with open(path, encoding="utf-8") as f:
                 content = f.read()
 
             # Find close methods without return type
@@ -86,7 +86,7 @@ class TestReturnTypeAnnotations:
         """All cleanup() methods should have -> None return type."""
         file_path = Path("src/tracklistify/core/base.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check cleanup has return type
@@ -99,7 +99,7 @@ class TestReturnTypeAnnotations:
         """Factory clear methods should have -> None return type."""
         file_path = Path("src/tracklistify/providers/factory.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         # Check clear_provider_cache has return type
@@ -120,7 +120,7 @@ class TestTypingImports:
         """cache/index.py should import Any from typing."""
         file_path = Path("src/tracklistify/cache/index.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)
@@ -139,7 +139,7 @@ class TestTypingImports:
         """cache/storage.py should import Any from typing."""
         file_path = Path("src/tracklistify/cache/storage.py")
 
-        with open(file_path) as f:
+        with open(file_path, encoding="utf-8") as f:
             content = f.read()
 
         tree = ast.parse(content)

--- a/tests/test_validation.py
+++ b/tests/test_validation.py
@@ -68,6 +68,59 @@ def test_file_uri_nonexistent(tmp_path: Path):
     assert validate_input(uri) is None
 
 
+def test_file_uri_with_space_in_name(tmp_path: Path):
+    """A percent-escaped space must be decoded before the path is used.
+
+    Regression (#85): the old code fed ``urlparse().path`` straight into
+    ``Path``, so ``clip%20a.wav`` was looked up literally, never existed,
+    and a valid URI returned None. Not Windows-specific -- it fails on
+    POSIX too, and only escaped notice because tmp_path names have no
+    spaces.
+    """
+    f = tmp_path / "a mix (live).wav"
+    f.write_text("x")
+    uri = f.as_uri()
+    assert "%20" in uri  # guard: the fixture must actually exercise escaping
+
+    validated_path, is_local = validate_input(uri)
+    assert is_local is True
+    assert Path(validated_path).resolve() == f.resolve()
+
+
+def test_file_uri_with_non_ascii_name(tmp_path: Path):
+    """Non-ASCII is percent-escaped as UTF-8 bytes and must round-trip."""
+    f = tmp_path / "Björk - Jóga.wav"
+    f.write_text("x")
+    uri = f.as_uri()
+
+    validated_path, is_local = validate_input(uri)
+    assert is_local is True
+    assert Path(validated_path).resolve() == f.resolve()
+
+
+def test_file_uri_localhost_host_accepted(tmp_path: Path):
+    """``file://localhost/path`` is the same file as ``file:///path``."""
+    f = tmp_path / "clip.wav"
+    f.write_text("x")
+    uri = f.as_uri().replace("file://", "file://localhost", 1)
+
+    validated_path, is_local = validate_input(uri)
+    assert is_local is True
+    assert Path(validated_path).resolve() == f.resolve()
+
+
+def test_file_uri_remote_host_rejected_off_windows(monkeypatch):
+    """A host other than localhost is a UNC path -- meaningless on POSIX.
+
+    Silently dropping the host would resolve ``file://evil/etc/passwd`` to
+    the local ``/etc/passwd``, so it is rejected rather than reinterpreted.
+    """
+    import tracklistify.utils.validation as validation
+
+    monkeypatch.setattr(validation.sys, "platform", "linux")
+    assert validate_input("file://someserver/share/clip.wav") is None
+
+
 class TestCleanUrl:
     def test_strips_query_and_fragment(self):
         assert (

--- a/uv.lock
+++ b/uv.lock
@@ -1,5 +1,5 @@
 version = 1
-revision = 2
+revision = 3
 requires-python = ">=3.11, <3.14"
 resolution-markers = [
     "python_full_version >= '3.13'",
@@ -1363,7 +1363,7 @@ wheels = [
 
 [[package]]
 name = "pylint"
-version = "4.0.7"
+version = "4.0.8"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "astroid" },
@@ -1374,9 +1374,9 @@ dependencies = [
     { name = "platformdirs" },
     { name = "tomlkit" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/de/92/98dace02f2d11b88160354c53944f77ea7327aa78bce1c75971e7aaa4347/pylint-4.0.7.tar.gz", hash = "sha256:9b2d1d15791c84b77a4fe2aafe8f0d9570717e2dea06d53b19c105cf60275a52", size = 1594770, upload-time = "2026-08-09T19:13:23.289Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5c/2e/424cbfcb3af792a6b7da6e5c640de463b98c8d3a49fbd8882f38e83d4232/pylint-4.0.8.tar.gz", hash = "sha256:1c1b2128bde5ff5e966801413080b6384d42a5782718d528c906dbb6beab94ed", size = 1599177, upload-time = "2026-08-29T12:21:59.188Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e0/b0/3a8040e53df6c5c1e04b0e23ed53fdbeb64f333723a334d313fba2f581ce/pylint-4.0.7-py3-none-any.whl", hash = "sha256:be4a3111557a614411ed1fc89347ce4a8e1013a59e1f33d11485227a02e3304d", size = 539710, upload-time = "2026-08-09T19:13:21.228Z" },
+    { url = "https://files.pythonhosted.org/packages/2b/ea/9b601859afa055afe659ffe55abdfed6e5f17e17a840d9cd61c54ac89c02/pylint-4.0.8-py3-none-any.whl", hash = "sha256:3341c08c0aabaa4adc71516de0969f3ba5c692b56c75af4dcb4d242823fbe363", size = 540709, upload-time = "2026-08-29T12:21:57.392Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
Closes #85. Splits out the 13 failures @deroverda found on Windows 10 x86-64 that reproduce on `main` and were unrelated to #84.

Four causes. One is a real bug with a symptom on every platform; three are tests that encoded the host OS into assertions that are not about it.

## `file://` URIs were never percent-decoded — `1329a82`

`validate_input` built the path with `Path(urlparse(s).path)`. `urlparse` returns a *URL* path, not a filesystem path, so escapes stay encoded:

```
file:///home/x/clip%20a.wav  ->  Path('/home/x/clip%20a.wav')   # does not exist -> None
file:///C:/x/clip.wav        ->  Path('/C:/x/clip.wav')          # leading slash, invalid on Windows
```

**This is not a Windows bug.** Any `file://` URI with a space or a non-ASCII character has been failing on macOS and Linux too. It went unnoticed because every existing test builds its URI from a `tmp_path` name, and those have no spaces. `url2pathname` unquotes and denormalizes per platform.

While in there: the authority component was being dropped silently. `file://localhost/p` is defined to be the same file as `file:///p` and is now accepted; any other host is a Windows UNC path, rebuilt as `\\host\share` there and rejected elsewhere. Dropping it meant `file://evil/etc/passwd` resolved to the local `/etc/passwd`.

The three new path-decoding tests fail against the previous implementation — verified by stashing the source fix and re-running:

```
FAILED tests/test_validation.py::test_file_uri_with_space_in_name
FAILED tests/test_validation.py::test_file_uri_with_non_ascii_name
FAILED tests/test_validation.py::test_file_uri_remote_host_rejected_off_windows
```

## Locale encoding on text I/O — `63c4fd4`

Bare `open()` uses `locale.getpreferredencoding()` — cp1252 on a default Windows install. `core/track.py` has 51 non-ASCII lines (em-dashes in comments, `ROSALÍA` / `Björk` in the artist-matching docstrings), and cp1252 dies on the first:

```
'charmap' codec can't decode byte 0x8d in position 1130: character maps to <undefined>
```

That is what broke the source-scanning tests. 61 call sites across 12 test files, not the 22 I estimated when filing the issue.

Four production sites had the same latent bug and are fixed in the same pass: `core/run.py` (the `.env.example` → `.env` copy — ASCII today, would corrupt the file the moment a non-ASCII default appeared), `providers/beatport.py` (token cache — currently safe only because `json.dumps` escapes non-ASCII by default), and `config/validation.py`, which opens paths purely to probe readability and appendability. That last one decodes nothing, so it moved to binary mode rather than naming an encoding it never uses.

No behavior change on POSIX, where the locale encoding was already UTF-8.

## POSIX-only assertions — `2683db1`

`st_mode & 0o777 == 0o600` on the Beatport token cache: NTFS has ACLs, not mode bits, and CPython's `Path.chmod` only toggles the read-only flag there, so `st_mode` returns `0o666` whatever the source asked. Guarded by `os.name == "posix"` rather than weakened — the 0600 is the point of the test where the bits mean something. Hardening the token file on Windows would be a feature, not a test change.

`.endswith(".tracklistify/output")`: Windows renders it with a backslash. Now compares `Path.parts`.

## Checked and deliberately left alone

- `test_app.py:637` mocks a download returning `/tmp/downloaded.mp3` — a return value that never touches disk.
- `test_cli_arguments.py:578` asserts `SIGTERM`/`SIGINT` registration; both exist on Windows.
- `get_ffmpeg_path()` probes three POSIX paths, then falls back to `shutil.which("ffmpeg")`, which finds `ffmpeg.exe` fine.

## Verification

```
uv run python -m pytest -q                        735 passed, 1 skipped
uv run ruff check src/ tests/                     All checks passed!
uv run python scripts/check_mypy_baseline.py      0 new, 0 fixed
uv run python scripts/generate_env_example.py --check   up to date
```

Still POSIX-only verification — I have no Windows host. @deroverda, if you have another few minutes, this branch should take your 13 down to the 2 `file://` ones passing for the first time and the rest skipping or passing cleanly.

Version stays `0.11.2` and the changelog heading stays Unreleased; this ships in the same release as #84.
