### PR TITLE
docs: date the 0.11.2 release

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Release dates are in YYYY-MM-DD format.
 
-## [0.11.2] - Unreleased
+## [0.11.2] - 2026-09-03
 
 ### Fixed
 


### PR DESCRIPTION
Single line change: `## [0.11.2] - Unreleased` -> `## [0.11.2] - 2026-09-03`.

Everything that was waiting on it has landed — #84 (Windows startup crashes), #87 (path/encoding portability, folding in #86's pylint bump). `pyproject.toml` has carried 0.11.2 since eba7193, so **do not run `cz bump`** on merge; it would roll to 0.11.3. The tag is the only remaining step:

```
git tag -a v0.11.2 -m "Windows startup crashes, path and encoding portability, dependency bumps"
git push origin v0.11.2
```

Gates on this branch:

```
uv run python -m pytest -q                              735 passed, 1 skipped
uv run ruff check src/ tests/ scripts/                  All checks passed!
uv run ruff format --check src/ tests/ scripts/         111 files already formatted
uv run python scripts/check_mypy_baseline.py            0 new, 0 fixed
uv run python scripts/generate_env_example.py --check   up to date
importlib.metadata.version("tracklistify")              0.11.2
```
