### PR TITLE
bump: version 0.11.2 → 0.11.3

### DIFF
--- a/docs/CHANGELOG.md
+++ b/docs/CHANGELOG.md
@@ -7,7 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 Release dates are in YYYY-MM-DD format.
 
-## [Unreleased]
+## [0.11.3] - 2026-09-03
+
+Ships one fix every user of 0.11.2 needs: that release's lock pinned a
+yt-dlp a month behind YouTube's current player clients, so every YouTube
+download returned HTTP 403. The rest is the CI that would have caught it.
 
 ### Fixed
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "uv_build"
 
 [project]
 name = "tracklistify"
-version = "0.11.2"
+version = "0.11.3"
 description = "Automatic tracklist generator for DJ mixes and audio streams"
 readme = "README.md"
 authors = [

--- a/uv.lock
+++ b/uv.lock
@@ -1696,7 +1696,7 @@ wheels = [
 
 [[package]]
 name = "tracklistify"
-version = "0.11.2"
+version = "0.11.3"
 source = { editable = "." }
 dependencies = [
     { name = "aiohttp" },


### PR DESCRIPTION
Release prep. `pyproject.toml` 0.11.2 → 0.11.3, `uv.lock` follows, changelog heading dated.

**Why a release now, and why patch.** No new user-facing functionality — Windows CI, the live probes and the dependabot guardrail are all infrastructure. But 0.11.2 is the current "Latest" release and it **cannot download from YouTube**: its lock pinned yt-dlp `2026.7.4` against player clients YouTube had already retired, so every download returns HTTP 403. Anyone installing 0.11.2 today gets an app that fails on its primary input path. That is worth shipping on its own.

`from tracklistify import *` also works again (#89) — public API that was raising `AttributeError`.

Hand-edited rather than `cz bump`, per `docs/PLAYBOOKS.md` → Release: cz runs the non-incremental changelog generator and would overwrite the curated history.

## Verification

```
uv run python -m pytest -q                          749 passed, 3 skipped
uv run ruff check src/ tests/ scripts/              All checks passed!
uv run python scripts/check_mypy_baseline.py        0 new, 0 fixed
uv run python scripts/check_dependabot_config.py    OK: 1 entry, 3 groups
uv run python -c "import tracklistify; print(tracklistify.__version__)"   0.11.3
```

That last line is the #89 fix demonstrating itself — on 0.11.2 it raised `AttributeError`.

## After merge

Tag on `main` **after** the squash lands, not before — last release the tag went on the pre-squash commit and had to be redone:

```
git checkout main && git pull --ff-only origin main
git tag -a v0.11.3 -m "yt-dlp refresh, Windows CI, package metadata"
git push origin v0.11.3
```
